### PR TITLE
Arbitrary AE event tracking

### DIFF
--- a/src/Tutor.Core/DomainModel/AssessmentEvents/ArrangeTasks/ArrangeTask.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/ArrangeTasks/ArrangeTask.cs
@@ -9,6 +9,12 @@ namespace Tutor.Core.DomainModel.AssessmentEvents.ArrangeTasks
         public string Text { get; private set; }
         public List<ArrangeTaskContainer> Containers { get; private set; }
 
+        public override void ValidateInteraction(AssessmentEventInteraction interaction)
+        {
+            if (interaction is not ArrangeTaskInteraction)
+                throw new ArgumentException("Incorrect interaction supplied to Arrange Task with ID " + Id);
+        }
+
         public override Evaluation EvaluateSubmission(Submission submission)
         {
             if (submission is ArrangeTaskSubmission atSubmission) return EvaluateAT(atSubmission);
@@ -18,7 +24,7 @@ namespace Tutor.Core.DomainModel.AssessmentEvents.ArrangeTasks
         private Evaluation EvaluateAT(ArrangeTaskSubmission atSubmission)
         {
             var evaluations = EvaluateContainers(atSubmission.Containers);
-            var correctness = (double) evaluations.Count(c => c.SubmissionWasCorrect) / evaluations.Count;
+            var correctness = (double)evaluations.Count(c => c.SubmissionWasCorrect) / evaluations.Count;
 
             return new ArrangeTaskEvaluation(Id, correctness, evaluations);
         }

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/ArrangeTasks/ArrangeTaskInteraction.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/ArrangeTasks/ArrangeTaskInteraction.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents.ArrangeTasks
+{
+    public abstract class ArrangeTaskInteraction : AssessmentEventInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/AssessmentEvent.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/AssessmentEvent.cs
@@ -20,6 +20,8 @@ namespace Tutor.Core.DomainModel.AssessmentEvents
 
         public abstract Evaluation EvaluateSubmission(Submission submission);
 
+        public abstract void ValidateInteraction(AssessmentEventInteraction interaction);
+
         public double GetMaximumSubmissionCorrectness()
         {
             return Submissions.Any() ? Submissions.OrderBy(sub => sub.CorrectnessLevel).Last().CorrectnessLevel : 0.0;

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/AssessmentEventInteraction.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/AssessmentEventInteraction.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents
+{
+    public abstract class AssessmentEventInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/AssessmentEventInteractionService.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/AssessmentEventInteractionService.cs
@@ -1,0 +1,39 @@
+﻿using FluentResults;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tutor.Core.DomainModel.KnowledgeComponents;
+
+namespace Tutor.Core.DomainModel.AssessmentEvents
+{
+    public class AssessmentEventInteractionService : IAssessmentEventInteractionService
+    {
+        private readonly IAssessmentEventRepository _assessmentEventRepository;
+        private readonly IKCRepository _kcRepository;
+
+        public AssessmentEventInteractionService(IAssessmentEventRepository assessmentEventRepository, IKCRepository kcRepository)
+        {
+            _assessmentEventRepository = assessmentEventRepository;
+            _kcRepository = kcRepository;
+        }
+
+        public Result Interact(int learnerId, int assessmentEventId, AssessmentEventInteraction interaction)
+        {
+            var assessmentEvent = _assessmentEventRepository.GetDerivedAssessmentEvent(assessmentEventId);
+            if (assessmentEvent == null)
+                return Result.Fail("No assessment event with ID: " + assessmentEventId);
+
+            var knowledgeComponentMastery = _kcRepository.GetKnowledgeComponentMastery(learnerId, assessmentEvent.KnowledgeComponentId);
+            if (knowledgeComponentMastery == null)
+                return Result.Fail("The Learner isn't enrolled to knowledge component with ID: " + assessmentEvent.KnowledgeComponentId);
+
+            var result = knowledgeComponentMastery.InteractWithAssessmentEvent(assessmentEventId, interaction);
+
+            _kcRepository.UpdateKCMastery(knowledgeComponentMastery);
+
+            return result;
+        }
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/Challenge.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/Challenge.cs
@@ -2,6 +2,7 @@
 using CodeModel.CaDETModel;
 using System;
 using System.Collections.Generic;
+using Tutor.Core.DomainModel.AssessmentEvents.Challenges.ChallengeInteractions;
 using Tutor.Core.DomainModel.AssessmentEvents.Challenges.FulfillmentStrategy;
 using Tutor.Core.DomainModel.AssessmentEvents.Challenges.FunctionalityTester;
 
@@ -19,6 +20,12 @@ namespace Tutor.Core.DomainModel.AssessmentEvents.Challenges
         public Challenge(int id, int learningObjectSummaryId, List<ChallengeFulfillmentStrategy> fulfillmentStrategies) : base(id, learningObjectSummaryId)
         {
             FulfillmentStrategies = fulfillmentStrategies;
+        }
+
+        public override void ValidateInteraction(AssessmentEventInteraction interaction)
+        {
+            if (interaction is not ChallengeInteraction)
+                throw new ArgumentException("Incorrect interaction supplied to challenge with ID " + Id);
         }
 
         public override Evaluation EvaluateSubmission(Submission submission)

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/ChallengeInteractions/ChallengeInteraction.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/ChallengeInteractions/ChallengeInteraction.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents.Challenges.ChallengeInteractions
+{
+    public abstract class ChallengeInteraction : AssessmentEventInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/ChallengeInteractions/HintsSought.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/ChallengeInteractions/HintsSought.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents.Challenges.ChallengeInteractions
+{
+    public class HintsSought : ChallengeInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/ChallengeInteractions/SolutionSought.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/Challenges/ChallengeInteractions/SolutionSought.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents.Challenges.ChallengeInteractions
+{
+    public class SolutionSought : ChallengeInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/IAssessmentEventInteractionService.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/IAssessmentEventInteractionService.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+
+namespace Tutor.Core.DomainModel.AssessmentEvents
+{
+    public interface IAssessmentEventInteractionService
+    {
+        Result Interact(int learnerId, int assessmentEventId, AssessmentEventInteraction interaction);
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/MultiResponseQuestions/MRQ.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/MultiResponseQuestions/MRQ.cs
@@ -9,6 +9,12 @@ namespace Tutor.Core.DomainModel.AssessmentEvents.MultiResponseQuestions
         public string Text { get; private set; }
         public List<MrqItem> Items { get; private set; }
 
+        public override void ValidateInteraction(AssessmentEventInteraction interaction)
+        {
+            if (interaction is not MrqInteraction)
+                throw new ArgumentException("Incorrect interaction supplied to MRQ with ID " + Id);
+        }
+
         public override Evaluation EvaluateSubmission(Submission submission)
         {
             if (submission is MrqSubmission mrqSubmission) return EvaluateMrq(mrqSubmission);
@@ -19,7 +25,7 @@ namespace Tutor.Core.DomainModel.AssessmentEvents.MultiResponseQuestions
         {
             var answerEvaluations = CheckAnswers(mrqSubmission.SubmittedAnswerIds);
             var correctness = (double)answerEvaluations.Count(a => a.SubmissionWasCorrect) / answerEvaluations.Count;
-            
+
             return new MrqEvaluation(Id, correctness, answerEvaluations);
         }
 

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/MultiResponseQuestions/MrqInteraction.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/MultiResponseQuestions/MrqInteraction.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents.MultiResponseQuestions
+{
+    public abstract class MrqInteraction : AssessmentEventInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/ShortAnswerQuestions/Saq.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/ShortAnswerQuestions/Saq.cs
@@ -9,6 +9,12 @@ namespace Tutor.Core.DomainModel.AssessmentEvents.ShortAnswerQuestions
         public string Text { get; private set; }
         public List<string> AcceptableAnswers { get; private set; }
 
+        public override void ValidateInteraction(AssessmentEventInteraction interaction)
+        {
+            if (interaction is not SaqInteraction)
+                throw new ArgumentException("Incorrect interaction supplied to SAQ with ID " + Id);
+        }
+
         public override Evaluation EvaluateSubmission(Submission submission)
         {
             if (submission is SaqSubmission saqSubmission) return EvaluateSaq(saqSubmission);

--- a/src/Tutor.Core/DomainModel/AssessmentEvents/ShortAnswerQuestions/SaqInteraction.cs
+++ b/src/Tutor.Core/DomainModel/AssessmentEvents/ShortAnswerQuestions/SaqInteraction.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.DomainModel.AssessmentEvents.ShortAnswerQuestions
+{
+    public abstract class SaqInteraction : AssessmentEventInteraction
+    {
+    }
+}

--- a/src/Tutor.Core/DomainModel/KnowledgeComponents/InteractedWithAssessmentEvent.cs
+++ b/src/Tutor.Core/DomainModel/KnowledgeComponents/InteractedWithAssessmentEvent.cs
@@ -1,0 +1,12 @@
+﻿using Tutor.Core.BuildingBlocks.EventSourcing;
+using Tutor.Core.DomainModel.AssessmentEvents;
+
+namespace Tutor.Core.DomainModel.KnowledgeComponents
+{
+    public class InteractedWithAssessmentEvent : DomainEvent
+    {
+        public int LearnerId { get; set; }
+        public int AssessmentEventId { get; set; }
+        public AssessmentEventInteraction Interaction { get; set; }
+    }
+}

--- a/src/Tutor.Core/DomainModel/KnowledgeComponents/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/DomainModel/KnowledgeComponents/KnowledgeComponentMastery.cs
@@ -54,6 +54,31 @@ namespace Tutor.Core.DomainModel.KnowledgeComponents
             return assessmentEventSelector.SelectSuitableAssessmentEvent(KnowledgeComponent.Id, LearnerId);
         }
 
+        public Result InteractWithAssessmentEvent(int assessmentEventId, AssessmentEventInteraction interaction)
+        {
+            var assessmentEvent = KnowledgeComponent.GetAssessmentEvent(assessmentEventId);
+            if (assessmentEvent == null)
+                return Result.Fail("No assessment event with ID: " + assessmentEventId);
+
+            try
+            {
+                assessmentEvent.ValidateInteraction(interaction);
+            }
+            catch (ArgumentException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+
+            Causes(new InteractedWithAssessmentEvent()
+            {
+                LearnerId = LearnerId,
+                AssessmentEventId = assessmentEventId,
+                Interaction = interaction
+            });
+
+            return Result.Ok();
+        }
+
         protected override void Apply(DomainEvent @event)
         {
             When((dynamic)@event);
@@ -76,6 +101,11 @@ namespace Tutor.Core.DomainModel.KnowledgeComponents
                 * (@event.CorrectnessLevel - currentCorrectnessLevel) / 100.0;
 
             Mastery += kcMasteryIncrement;
+        }
+
+        private void When(InteractedWithAssessmentEvent @event)
+        {
+            // This method will probably do nothing
         }
     }
 }

--- a/src/Tutor.Infrastructure/Serialization/EventSerializer.cs
+++ b/src/Tutor.Infrastructure/Serialization/EventSerializer.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Tutor.Core.BuildingBlocks.EventSourcing;
+using Tutor.Core.DomainModel.AssessmentEvents.Challenges.ChallengeInteractions;
 using Tutor.Core.DomainModel.KnowledgeComponents;
 
 namespace Tutor.Infrastructure.Serialization
@@ -12,13 +13,16 @@ namespace Tutor.Infrastructure.Serialization
     {
         private static readonly IDictionary<Type, string> eventRelatedTypes = new Dictionary<Type, string>()
         {
-            { typeof(AssessmentEventAnswered), "AssessmentEventAnswered"}
+            { typeof(AssessmentEventAnswered), "AssessmentEventAnswered" },
+            { typeof(InteractedWithAssessmentEvent), "InteractedWithAssessmentEvent" },
+            { typeof(HintsSought), "HintsSought" },
+            { typeof(SolutionSought), "SolutionSought" }
         };
 
         public static JsonSerializerOptions SetupEvents(this JsonSerializerOptions options)
         {
             DiscriminatorConventionRegistry registry = options.GetDiscriminatorConventionRegistry();
-            registry.RegisterConvention(new AllowedTypesDiscriminatorConvention<string>(options, eventRelatedTypes, "$discriminator"));
+            registry.RegisterConvention(new AllowedTypesDiscriminatorConvention<string>(options, eventRelatedTypes, "type"));
 
             foreach (Type type in eventRelatedTypes.Keys)
             {

--- a/src/Tutor.Web/Controllers/Plugin/PluginController.cs
+++ b/src/Tutor.Web/Controllers/Plugin/PluginController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Tutor.Core.DomainModel.AssessmentEvents;
 using Tutor.Core.DomainModel.AssessmentEvents.Challenges;
+using Tutor.Core.DomainModel.AssessmentEvents.Challenges.ChallengeInteractions;
 using Tutor.Core.LearnerModel;
 using Tutor.Web.Controllers.Domain.DTOs.AssessmentEvents.Challenge;
 using Tutor.Web.Controllers.Learners.DTOs;
@@ -16,12 +17,14 @@ namespace Tutor.Web.Controllers.Plugin
         private readonly ILearnerRepository _learnerRepository;
         private readonly IMapper _mapper;
         private readonly ISubmissionService _submissionService;
+        private readonly IAssessmentEventInteractionService _assessmentEventInteractionService;
 
-        public PluginController(ILearnerRepository learnerRepository, ISubmissionService submissionService, IMapper mapper)
+        public PluginController(ILearnerRepository learnerRepository, IMapper mapper, ISubmissionService submissionService, IAssessmentEventInteractionService assessmentEventInteractionService)
         {
             _learnerRepository = learnerRepository;
-            _submissionService = submissionService;
             _mapper = mapper;
+            _submissionService = submissionService;
+            _assessmentEventInteractionService = assessmentEventInteractionService;
         }
 
         [HttpPost("login")]
@@ -39,6 +42,20 @@ namespace Tutor.Web.Controllers.Plugin
             var result = _submissionService.EvaluateAndSaveSubmission(_mapper.Map<ChallengeSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<ChallengeEvaluationDto>(result.Value));
+        }
+
+        [HttpPost("challenge/hints")]
+        public void SeekHints([FromBody] ChallengeSubmissionDto submission)
+        {
+            _assessmentEventInteractionService
+                .Interact(submission.LearnerId, submission.AssessmentEventId, new HintsSought());
+        }
+
+        [HttpPost("challenge/solution")]
+        public void SeekSolution([FromBody] ChallengeSubmissionDto submission)
+        {
+            _assessmentEventInteractionService
+                .Interact(submission.LearnerId, submission.AssessmentEventId, new SolutionSought());
         }
     }
 }

--- a/src/Tutor.Web/Startup.cs
+++ b/src/Tutor.Web/Startup.cs
@@ -88,6 +88,7 @@ namespace Tutor.Web
             services.AddScoped<IAssessmentEventRepository, AssessmentEventDatabaseRepository>();
             services.AddScoped<ISubmissionService, SubmissionService>();
             services.AddScoped<IAssessmentEventSelector, LeastCorrectAssessmentEventSelector>();
+            services.AddScoped<IAssessmentEventInteractionService, AssessmentEventInteractionService>();
 
             services.AddScoped<ILearnerService, LearnerService>();
             services.Configure<WorkspaceOptions>(Configuration.GetSection(WorkspaceOptions.ConfigKey));


### PR DESCRIPTION
This PR is an attempt to design a functionality that would allow us to record arbitrary events related to AEs, while still validating whether or not the event is suitable for the AE in question (as proposed in https://github.com/Clean-CaDET/tutor/pull/26#discussion_r827821326). The idea is that various interactions with AEs would be added through this if we currently just want to record that they happened, without any change in the domain happening as a consequence of the interaction happening. Specific interactions could later be extracted and implemented separately (similarly to how answering AEs / submission evaluation is implemented) if necessary. 
