### PR TITLE
Session abandonment tracking

### DIFF
--- a/src/Tutor.Core/DomainModel/KnowledgeComponents/IKCService.cs
+++ b/src/Tutor.Core/DomainModel/KnowledgeComponents/IKCService.cs
@@ -24,5 +24,7 @@ namespace Tutor.Core.DomainModel.KnowledgeComponents
         Result LaunchSession(int learnerId, int knowledgeComponentId);
 
         Result TerminateSession(int learnerId, int knowledgeComponentId);
+
+        Result AbandonSession(int learnerId, int knowledgeComponentId);
     }
 }

--- a/src/Tutor.Core/DomainModel/KnowledgeComponents/KCService.cs
+++ b/src/Tutor.Core/DomainModel/KnowledgeComponents/KCService.cs
@@ -83,5 +83,13 @@ namespace Tutor.Core.DomainModel.KnowledgeComponents
             _kcRepository.UpdateKCMastery(knowledgeComponentMastery);
             return result;
         }
+
+        public Result AbandonSession(int learnerId, int knowledgeComponentId)
+        {
+            var knowledgeComponentMastery = _kcRepository.GetKnowledgeComponentMastery(learnerId, knowledgeComponentId);
+            var result = knowledgeComponentMastery.AbandonSession();
+            _kcRepository.UpdateKCMastery(knowledgeComponentMastery);
+            return result;
+        }
     }
 }

--- a/src/Tutor.Core/DomainModel/KnowledgeComponents/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/DomainModel/KnowledgeComponents/KnowledgeComponentMastery.cs
@@ -73,6 +73,19 @@ namespace Tutor.Core.DomainModel.KnowledgeComponents
             return Result.Ok();
         }
 
+        public Result AbandonSession()
+        {
+            if (!HasActiveSession)
+                return Result.Fail("No active session to abandon.");
+
+            Causes(new SessionAbandoned()
+            {
+                KnowledgeComponentId = KnowledgeComponent.Id,
+                LearnerId = LearnerId
+            });
+            return Result.Ok();
+        }
+
         public Result<Evaluation> SubmitAssessmentEventAnswer(Submission submission)
         {
             if (!HasActiveSession)

--- a/src/Tutor.Web/Hubs/SessionHub.cs
+++ b/src/Tutor.Web/Hubs/SessionHub.cs
@@ -15,34 +15,22 @@ namespace Tutor.Web.Hubs
             _kcService = kcService;
         }
 
-        //public void LaunchSession(int knowledgeComponentId)
-        //{
-        //    var result = _kcService.LaunchSession(Context.User.Id(), knowledgeComponentId);
-        //    if (result.IsSuccess)
-        //        Context.Items.Add("knowledgeComponentId", knowledgeComponentId);
-        //}
-
-        public void LaunchSession(int knowledgeComponentId, int learnerId)
+        public void LaunchSession(int knowledgeComponentId)
         {
-            var result = _kcService.LaunchSession(learnerId, knowledgeComponentId);
+            var result = _kcService.LaunchSession(Context.User.Id(), knowledgeComponentId);
             if (result.IsSuccess)
-            {
                 Context.Items.Add("knowledgeComponentId", knowledgeComponentId);
-                Context.Items.Add("learnerId", learnerId);
-            }
         }
 
         public override async Task OnDisconnectedAsync(Exception exception)
         {
             object knowledgeComponentId;
-            object  learnerId;
-            if (Context.Items.TryGetValue("knowledgeComponentId", out knowledgeComponentId)
-                && Context.Items.TryGetValue("learnerId", out learnerId))
+            if (Context.Items.TryGetValue("knowledgeComponentId", out knowledgeComponentId))
             {
                 if (exception == null)
-                    _kcService.TerminateSession((learnerId as int?).Value, (knowledgeComponentId as int?).Value);
+                    _kcService.TerminateSession(Context.User.Id(), (knowledgeComponentId as int?).Value);
                 else
-                    _kcService.AbandonSession((learnerId as int?).Value, (knowledgeComponentId as int?).Value);
+                    _kcService.AbandonSession(Context.User.Id(), (knowledgeComponentId as int?).Value);
             }
             await base.OnDisconnectedAsync(exception);
         }

--- a/src/Tutor.Web/Hubs/SessionHub.cs
+++ b/src/Tutor.Web/Hubs/SessionHub.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Threading.Tasks;
+using Tutor.Core.DomainModel.KnowledgeComponents;
+using Tutor.Infrastructure.Security.Authorization.JWT;
+
+namespace Tutor.Web.Hubs
+{
+    public class SessionHub : Hub
+    {
+        private readonly IKCService _kcService;
+
+        public SessionHub(IKCService kcService)
+        {
+            _kcService = kcService;
+        }
+
+        //public void LaunchSession(int knowledgeComponentId)
+        //{
+        //    var result = _kcService.LaunchSession(Context.User.Id(), knowledgeComponentId);
+        //    if (result.IsSuccess)
+        //        Context.Items.Add("knowledgeComponentId", knowledgeComponentId);
+        //}
+
+        public void LaunchSession(int knowledgeComponentId, int learnerId)
+        {
+            var result = _kcService.LaunchSession(learnerId, knowledgeComponentId);
+            if (result.IsSuccess)
+            {
+                Context.Items.Add("knowledgeComponentId", knowledgeComponentId);
+                Context.Items.Add("learnerId", learnerId);
+            }
+        }
+
+        public override async Task OnDisconnectedAsync(Exception exception)
+        {
+            object knowledgeComponentId;
+            object  learnerId;
+            if (Context.Items.TryGetValue("knowledgeComponentId", out knowledgeComponentId)
+                && Context.Items.TryGetValue("learnerId", out learnerId))
+            {
+                if (exception == null)
+                    _kcService.TerminateSession((learnerId as int?).Value, (knowledgeComponentId as int?).Value);
+                else
+                    _kcService.AbandonSession((learnerId as int?).Value, (knowledgeComponentId as int?).Value);
+            }
+            await base.OnDisconnectedAsync(exception);
+        }
+    }
+}

--- a/src/Tutor.Web/Startup.cs
+++ b/src/Tutor.Web/Startup.cs
@@ -157,6 +157,19 @@ namespace Tutor.Web
 
                     options.Events = new JwtBearerEvents
                     {
+                        OnMessageReceived = context =>
+                        {
+                            var accessToken = context.Request.Query["access_token"];
+                            var path = context.HttpContext.Request.Path;
+
+                            if (!string.IsNullOrEmpty(accessToken) &&
+                                path.StartsWithSegments("/api/session"))
+                            {
+                                // Read the token out of the query string
+                                context.Token = accessToken;
+                            }
+                            return Task.CompletedTask;
+                        },
                         OnAuthenticationFailed = context =>
                         {
                             if (context.Exception.GetType() == typeof(SecurityTokenExpiredException))
@@ -207,7 +220,7 @@ namespace Tutor.Web
                         return failedContext.Response.WriteAsync(Env.IsDevelopment()
                             ? failedContext.Exception.ToString()
                             : "An error occured processing your authentication.");
-                    }
+                    }                    
                 };
             });
         }

--- a/src/Tutor.Web/Startup.cs
+++ b/src/Tutor.Web/Startup.cs
@@ -33,6 +33,7 @@ using Tutor.Web.IAM.Keycloak;
 using Tutor.Infrastructure.Serialization;
 using Tutor.Core.DomainModel.Feedback;
 using Tutor.Core.DomainModel.KnowledgeComponents.MoveOn;
+using Tutor.Web.Hubs;
 
 namespace Tutor.Web
 {
@@ -79,10 +80,13 @@ namespace Tutor.Web
                     builder =>
                     {
                         builder.WithOrigins(ParseCorsOrigins())
+                            .AllowCredentials()
                             .WithHeaders(HeaderNames.ContentType, HeaderNames.Authorization, "access_token")
                             .WithMethods("GET", "PUT", "POST", "DELETE", "OPTIONS");
                     });
             });
+
+            services.AddSignalR();
 
             services.AddScoped<IKCService, KcService>();
             services.AddScoped<IKCRepository, KCDatabaseRepository>();
@@ -225,7 +229,11 @@ namespace Tutor.Web
 
             app.UseAuthorization();
 
-            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapHub<SessionHub>("/api/session");
+            });
         }
 
         private static string[] ParseCorsOrigins()


### PR DESCRIPTION
Implements session abandonment using SignalR.

Current issues with this:
- Token refresh for the SignalR connection needs to be handled.
- Negotiation when opening SignalR connection fails for some reason. Connection is successfully opened if settings are changed to skip negotiation and always only use web sockets as the transport method. I haven't been able to determine why this is happening yet.