### PR TITLE
fix: Fixes issue with database seeding for integration tests

### DIFF
--- a/tests/Tutor.Web.Tests/Integration/Analytics/KcStatisticsTests.cs
+++ b/tests/Tutor.Web.Tests/Integration/Analytics/KcStatisticsTests.cs
@@ -11,6 +11,8 @@ using Tutor.Web.Controllers.Analytics;
 using Xunit;
 
 namespace Tutor.Web.Tests.Integration.Analytics;
+
+[Collection("Sequential")]
 public class KcStatisticsTests : BaseWebIntegrationTest
 {
     public KcStatisticsTests(TutorApplicationTestFactory<Startup> factory) : base(factory) { }

--- a/tests/Tutor.Web.Tests/Integration/Analytics/LearnerProgressTests.cs
+++ b/tests/Tutor.Web.Tests/Integration/Analytics/LearnerProgressTests.cs
@@ -7,6 +7,8 @@ using Tutor.Web.Controllers.Analytics;
 using Xunit;
 
 namespace Tutor.Web.Tests.Integration.Analytics;
+
+[Collection("Sequential")]
 public class LearnerProgressTests : BaseWebIntegrationTest
 {
     public LearnerProgressTests(TutorApplicationTestFactory<Startup> factory) : base(factory) { }

--- a/tests/Tutor.Web.Tests/Integration/TutorTestFactory.cs
+++ b/tests/Tutor.Web.Tests/Integration/TutorTestFactory.cs
@@ -19,42 +19,29 @@ public class TutorApplicationTestFactory<TStartup> : WebApplicationFactory<Start
         builder.ConfigureServices(services =>
         {
             using var scope = BuildServiceProvider(services).CreateScope();
-            var scopedServices = scope.ServiceProvider;            
-            
+            var scopedServices = scope.ServiceProvider;  
             var db = scopedServices.GetRequiredService<TutorContext>();
-            db.Database.EnsureCreated();
-
-            InitializeEventDbForTests(scopedServices.GetRequiredService<EventContext>());
-
+            var eventDb = scopedServices.GetRequiredService<EventContext>();
             var logger = scopedServices.GetRequiredService<ILogger<TutorApplicationTestFactory<TStartup>>>();
-            try
-            {
-                InitializeDbForTests(db);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred seeding the database with test data. Error: {Message}", ex.Message);
-            }
+
+            InitializeDatabase(db, "../../../TestData/Scripts/", logger);
+            InitializeDatabase(eventDb, "../../../TestData/Scripts/Events/", logger);
         });
     }
 
-    private static void InitializeDbForTests(TutorContext db)
+    private static void InitializeDatabase(DbContext context, string scriptFolder, ILogger<TutorApplicationTestFactory<TStartup>> logger)
     {
-        var testScripts = Directory.GetFiles("../../../TestData/Scripts/");
-        var startingDb = string.Join('\n', testScripts.Select(File.ReadAllText));
-        db.Database.ExecuteSqlRaw(startingDb);
-    }
+        context.Database.EnsureCreated();
 
-    private static void InitializeEventDbForTests(EventContext db)
-    {
-        var createScript = db.Database.GenerateCreateScript();
         try
         {
-            db.Database.ExecuteSqlRaw(createScript);
+            var scriptFiles = Directory.GetFiles(scriptFolder);
+            var script = string.Join('\n', scriptFiles.Select(File.ReadAllText));
+            context.Database.ExecuteSqlRaw(script);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Triggers when the Events table already exists.
+            logger.LogError(ex, "An error occurred seeding the database with test data. Error: {Message}", ex.Message);
         }
     }
 
@@ -65,9 +52,8 @@ public class TutorApplicationTestFactory<TStartup> : WebApplicationFactory<Start
         var eventDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<EventContext>));
         services.Remove(eventDescriptor);
 
-        var connectionString = CreateConnectionStringForTest();
-        services.AddDbContext<TutorContext>(opt => opt.UseNpgsql(connectionString));
-        services.AddDbContext<EventContext>(opt => opt.UseNpgsql(connectionString));
+        services.AddDbContext<TutorContext>(opt => opt.UseNpgsql(CreateConnectionStringForTest()));
+        services.AddDbContext<EventContext>(opt => opt.UseNpgsql(CreateConnectionStringForEvents()));
         return services.BuildServiceProvider();
     }
 
@@ -76,6 +62,20 @@ public class TutorApplicationTestFactory<TStartup> : WebApplicationFactory<Start
         var server = Environment.GetEnvironmentVariable("DATABASE_HOST") ?? "localhost";
         var port = Environment.GetEnvironmentVariable("DATABASE_PORT") ?? "5432";
         var database = EnvironmentConnection.GetSecret("DATABASE_SCHEMA") ?? "smart-tutor-test";
+        var user = EnvironmentConnection.GetSecret("DATABASE_USERNAME") ?? "postgres";
+        var password = EnvironmentConnection.GetSecret("DATABASE_PASSWORD") ?? "super";
+        var integratedSecurity = Environment.GetEnvironmentVariable("DATABASE_INTEGRATED_SECURITY") ?? "false";
+        var pooling = Environment.GetEnvironmentVariable("DATABASE_POOLING") ?? "true";
+
+        return
+            $"Server={server};Port={port};Database={database};User ID={user};Password={password};Integrated Security={integratedSecurity};Pooling={pooling};";
+    }
+
+    private static string CreateConnectionStringForEvents()
+    {
+        var server = Environment.GetEnvironmentVariable("DATABASE_HOST") ?? "localhost";
+        var port = Environment.GetEnvironmentVariable("DATABASE_PORT") ?? "5432";
+        var database = EnvironmentConnection.GetSecret("EVENT_DATABASE_SCHEMA") ?? "smart-tutor-test-events";
         var user = EnvironmentConnection.GetSecret("DATABASE_USERNAME") ?? "postgres";
         var password = EnvironmentConnection.GetSecret("DATABASE_PASSWORD") ?? "super";
         var integratedSecurity = Environment.GetEnvironmentVariable("DATABASE_INTEGRATED_SECURITY") ?? "false";

--- a/tests/Tutor.Web.Tests/Integration/TutorTestFactory.cs
+++ b/tests/Tutor.Web.Tests/Integration/TutorTestFactory.cs
@@ -19,14 +19,14 @@ public class TutorApplicationTestFactory<TStartup> : WebApplicationFactory<Start
         builder.ConfigureServices(services =>
         {
             using var scope = BuildServiceProvider(services).CreateScope();
-            var scopedServices = scope.ServiceProvider;
-
-            InitializeEventDbForTests(scopedServices.GetRequiredService<EventContext>());
+            var scopedServices = scope.ServiceProvider;            
             
             var db = scopedServices.GetRequiredService<TutorContext>();
             db.Database.EnsureCreated();
-            var logger = scopedServices.GetRequiredService<ILogger<TutorApplicationTestFactory<TStartup>>>();
 
+            InitializeEventDbForTests(scopedServices.GetRequiredService<EventContext>());
+
+            var logger = scopedServices.GetRequiredService<ILogger<TutorApplicationTestFactory<TStartup>>>();
             try
             {
                 InitializeDbForTests(db);

--- a/tests/Tutor.Web.Tests/TestData/Scripts/Events/y-events.sql
+++ b/tests/Tutor.Web.Tests/TestData/Scripts/Events/y-events.sql
@@ -1,4 +1,6 @@
 ﻿
+DELETE FROM public."Events";
+
 INSERT INTO public."Events" VALUES (-266, 'KnowledgeComponentMastery', -9998, '2022-05-22 09:07:03.323641+02', '{{"LearnerId": -5, "TimeStamp": "2022-05-22T07:07:03.3236419Z", "$discriminator": "KnowledgeComponentStarted", "KnowledgeComponentId": -10}}');
 INSERT INTO public."Events" VALUES (-267, 'KnowledgeComponentMastery', -9998, '2022-05-22 09:07:03.372343+02', '{{"LearnerId": -5, "TimeStamp": "2022-05-22T07:07:03.372343Z", "$discriminator": "SessionLaunched", "KnowledgeComponentId": -10}}');
 INSERT INTO public."Events" VALUES (-268, 'KnowledgeComponentMastery', -9998, '2022-05-22 09:07:03.566225+02', '{{"LearnerId": -5, "TimeStamp": "2022-05-22T07:07:03.5662255Z", "$discriminator": "InstructionalItemsSelected", "KnowledgeComponentId": -10}}');

--- a/tests/Tutor.Web.Tests/TestData/Scripts/a-delete.sql
+++ b/tests/Tutor.Web.Tests/TestData/Scripts/a-delete.sql
@@ -5,7 +5,6 @@ DELETE FROM public."AssessmentItemMasteries";
 DELETE FROM public."KcMasteries";
 DELETE FROM public."UnitEnrollments";
 DELETE FROM public."Notes";
-DELETE FROM public."Events";
 DELETE FROM public."GroupMemberships";
 DELETE FROM public."LearnerGroups";
 DELETE FROM public."Learners";


### PR DESCRIPTION
- Makes the event database use a separate schema from the regular database in integration tests. Previously they used the same schema, which meant that EnsureCreated couldn't be used to initialize the Events table, and also that TutorContext had to be initialized before the Events table. 
- Adds the Collection attribute to integration test classes that were missing it. The missing attribute was causing concurrency issues with database initialization.