### PR TITLE
chore(ci): add release and deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    name: Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get the version
+        id: get-tag
+        run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./stacks/build/smart-tutor/Dockerfile
+          target: final
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/tutor:${{steps.get-tag.outputs.tag}}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/tutor:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/tutor:buildcache,mode=max
+      - name: Deploy service
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            docker service update \
+              --image ${{ secrets.DOCKER_HUB_USERNAME }}/tutor:${{steps.get-tag.outputs.tag}} \
+              --force clean_cadet_application_dev_smart-tutor

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+on:
+  workflow_run:
+    workflows: [Build]
+    branches: [master]
+    types:
+      - completed
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
Release workflow (triggered when build workflow successfully finish):

- Creates new release with appropriate tag based on [Angular Commit Massage Convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) . Requires PAT secret variable to be set on repository - GitHub Personal Access Token needs to be generated manually and it's value ti be set as PAT secret variable.

Deployment workflow (triggered when new tag is created):

- Build container image and publish to Docker Hub. Docker Hub username and API keys are required to be set as DOCKER_HUB_USERNAME, DOCKER_HUB_ACCESS_TOKEN as secrets.
- Deploys created image to server over ssh. Requires following secrets to be set: SSH_HOST, SSH_PORT, SSH_USERNAME, SSH_KEY