### PR TITLE
refactor: KnowledgeComponentMastery cleanup

### DIFF
--- a/src/Tutor.Core/DomainModel/KnowledgeComponents/KnowledgeComponent.cs
+++ b/src/Tutor.Core/DomainModel/KnowledgeComponents/KnowledgeComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Tutor.Core.DomainModel.AssessmentItems;
 using Tutor.Core.DomainModel.InstructionalItems;
 
@@ -17,5 +18,10 @@ namespace Tutor.Core.DomainModel.KnowledgeComponents
         public List<KnowledgeComponent> KnowledgeComponents { get; private set; }
         public List<AssessmentItem> AssessmentItems { get; private set; }
         public List<InstructionalItem> InstructionalItems { get; private set; }
+
+        public List<InstructionalItem> GetOrderedInstructionalItems()
+        {
+            return InstructionalItems.OrderBy(i => i.Order).ToList();
+        }
     }
 }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/ILearnerAssessmentService.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/ILearnerAssessmentService.cs
@@ -7,8 +7,8 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
     {
         Result<Evaluation> SubmitAssessmentItemAnswer(int learnerId, int assessmentItemId, Submission submission);
         Result<double> GetMaxCorrectness(int learnerId, int assessmentItemId);
-        Result SeekChallengeHints(int learnerId, int assessmentItemId);
-        Result SeekChallengeSolution(int learnerId, int assessmentItemId);
+        Result RecordHintRequest(int learnerId, int assessmentItemId);
+        Result RecordSolutionRequest(int learnerId, int assessmentItemId);
         Result RecordInstructorMessage(int learnerId, int kcId, string message);
     }
 }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/ILearnerAssessmentService.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/ILearnerAssessmentService.cs
@@ -5,10 +5,10 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
 {
     public interface ILearnerAssessmentService
     {
-        Result<Evaluation> EvaluateAndSaveSubmission(int learnerId, int assessmentItemId, Submission submission);
+        Result<Evaluation> SubmitAssessmentItemAnswer(int learnerId, int assessmentItemId, Submission submission);
         Result<double> GetMaxCorrectness(int learnerId, int assessmentItemId);
         Result SeekChallengeHints(int learnerId, int assessmentItemId);
         Result SeekChallengeSolution(int learnerId, int assessmentItemId);
-        Result SaveInstructorMessage(int learnerId, int kcId, string message);
+        Result RecordInstructorMessage(int learnerId, int kcId, string message);
     }
 }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KcMasteryService.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KcMasteryService.cs
@@ -26,7 +26,7 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
         public Result<KnowledgeUnit> GetUnit(int unitId, int learnerId)
         {
             var unit = _kcMasteryRepository.GetUnitWithKcs(unitId, learnerId);
-            if(unit == null) return Result.Fail("Learner not enrolled in KC: " + unitId);
+            if (unit == null) return Result.Fail("Learner not enrolled in KC: " + unitId);
 
             return Result.Ok(unit);
         }
@@ -48,11 +48,14 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
         {
             var kcMastery = _kcMasteryRepository.GetFullKcMastery(knowledgeComponentId, learnerId);
             if (kcMastery == null) return Result.Fail("Learner not enrolled in KC: " + knowledgeComponentId);
+            var knowledgeComponent = kcMastery.KnowledgeComponent;
 
-            var result = kcMastery.SelectInstructionalItems();
+            var result = kcMastery.RecordInstructionalItemSelection();
+            if (result.IsFailed) return result.ToResult<List<InstructionalItem>>();
+
             _kcMasteryRepository.UpdateKcMastery(kcMastery);
 
-            return result;
+            return Result.Ok(knowledgeComponent.GetOrderedInstructionalItems());
         }
 
         public Result<AssessmentItem> SelectSuitableAssessmentItem(int knowledgeComponentId, int learnerId)

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/AssessmentItemMastery.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/AssessmentItemMastery.cs
@@ -17,7 +17,7 @@ namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries
         public bool IsAttempted { get => SubmissionCount > 0; }
         public bool IsPassed { get => Mastery > PassThreshold; }
 
-        public void Select()
+        public void RecordSelection()
         {
             Causes(new AssessmentItemSelected()
             {

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/AssessmentItemMastery.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/AssessmentItemMastery.cs
@@ -37,13 +37,13 @@ namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries
 
         public Result RecordHintRequest()
         {
-            Causes(new SoughtHints());
+            Causes(new HintsRequested());
             return Result.Ok();
         }
 
         public Result RecordSolutionRequest()
         {
-            Causes(new SoughtSolution());
+            Causes(new SolutionRequested());
             return Result.Ok();
         }
 

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/AssessmentItemMastery.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/AssessmentItemMastery.cs
@@ -25,7 +25,7 @@ namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries
             });
         }
 
-        public void SubmitAnswer(Submission submission, Evaluation evaluation)
+        public void RecordAnswerSubmission(Submission submission, Evaluation evaluation)
         {
             Causes(new AssessmentItemAnswered
             {
@@ -35,13 +35,13 @@ namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries
             });
         }
 
-        public Result SeekHints()
+        public Result RecordHintRequest()
         {
             Causes(new SoughtHints());
             return Result.Ok();
         }
 
-        public Result SeekSolution()
+        public Result RecordSolutionRequest()
         {
             Causes(new SoughtSolution());
             return Result.Ok();

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/Events/AssessmentItemEvents/HelpRequested.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/Events/AssessmentItemEvents/HelpRequested.cs
@@ -1,6 +1,6 @@
 ﻿namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries.Events.AssessmentItemEvents
 {
-    public class SoughtHints : SoughtHelp
+    public abstract class HelpRequested : AssessmentItemEvent
     {
     }
 }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/Events/AssessmentItemEvents/HintsRequested.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/Events/AssessmentItemEvents/HintsRequested.cs
@@ -1,6 +1,6 @@
 ﻿namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries.Events.AssessmentItemEvents
 {
-    public class SoughtSolution : SoughtHelp
+    public class HintsRequested : HelpRequested
     {
     }
 }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/Events/AssessmentItemEvents/SolutionRequested.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/Events/AssessmentItemEvents/SolutionRequested.cs
@@ -1,6 +1,6 @@
 ﻿namespace Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries.Events.AssessmentItemEvents
 {
-    public abstract class SoughtHelp : AssessmentItemEvent
+    public class SolutionRequested : HelpRequested
     {
     }
 }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/KnowledgeComponentMastery.cs
@@ -77,17 +77,15 @@ public class KnowledgeComponentMastery : EventSourcedAggregateRoot
         return Result.Ok();
     }
 
-    public Result<int> SelectAssessmentItem(IAssessmentItemSelector assessmentItemSelector)
+    public Result RecordAssessmentItemSelection(int assessmentItemId)
     {
-        var result = assessmentItemSelector.SelectSuitableAssessmentItemId(AssessmentItemMasteries, IsPassed);
-        if (result.IsFailed) return result;
-
-        var aim = AssessmentItemMasteries.Find(aim => aim.AssessmentItemId == result.Value);
-        if (aim == null) return NoAssessmentItemWithId(result.Value);
+        var aim = AssessmentItemMasteries.Find(aim => aim.AssessmentItemId == assessmentItemId);
+        if (aim == null) return NoAssessmentItemWithId(assessmentItemId);
 
         JoinOrLaunchSession();
-        aim.Select();
-        return result;
+        aim.RecordSelection();
+
+        return Result.Ok();
     }
 
     public Result SubmitAssessmentItemAnswer(int assessmentItemId, Submission submission, Evaluation evaluation)

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/KnowledgeComponentMastery.cs
@@ -70,12 +70,11 @@ public class KnowledgeComponentMastery : EventSourcedAggregateRoot
         if (!SessionTracker.HasUnfinishedSession) LaunchSession();
     }
 
-    public Result<List<InstructionalItem>> SelectInstructionalItems()
+    public Result RecordInstructionalItemSelection()
     {
         JoinOrLaunchSession();
-
         Causes(new InstructionalItemsSelected());
-        return Result.Ok(KnowledgeComponent.InstructionalItems.OrderBy(i => i.Order).ToList());
+        return Result.Ok();
     }
 
     public Result<int> SelectAssessmentItem(IAssessmentItemSelector assessmentItemSelector)

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/KnowledgeComponentMasteries/KnowledgeComponentMastery.cs
@@ -88,13 +88,13 @@ public class KnowledgeComponentMastery : EventSourcedAggregateRoot
         return Result.Ok();
     }
 
-    public Result SubmitAssessmentItemAnswer(int assessmentItemId, Submission submission, Evaluation evaluation)
+    public Result RecordAssessmentItemAnswerSubmission(int assessmentItemId, Submission submission, Evaluation evaluation)
     {
         var aim = AssessmentItemMasteries.Find(aim => aim.AssessmentItemId == assessmentItemId);
         if (aim == null) return NoAssessmentItemWithId(assessmentItemId);
 
         JoinOrLaunchSession();
-        aim.SubmitAnswer(submission, evaluation);
+        aim.RecordAnswerSubmission(submission, evaluation);
         TryPass();
         TryComplete();
 
@@ -124,22 +124,22 @@ public class KnowledgeComponentMastery : EventSourcedAggregateRoot
         Causes(new KnowledgeComponentSatisfied());
     }
 
-    public Result SeekHintsForAssessmentItem(int assessmentItemId)
+    public Result RecordAssessmentItemHintRequest(int assessmentItemId)
     {
         var aim = AssessmentItemMasteries.Find(aim => aim.AssessmentItemId == assessmentItemId);
         if (aim == null) return NoAssessmentItemWithId(assessmentItemId);
 
         JoinOrLaunchSession();
-        return aim.SeekHints();
+        return aim.RecordHintRequest();
     }
 
-    public Result SeekSolutionForAssessmentItem(int assessmentItemId)
+    public Result RecordAssessmentItemSolutionRequest(int assessmentItemId)
     {
         var aim = AssessmentItemMasteries.Find(aim => aim.AssessmentItemId == assessmentItemId);
         if (aim == null) return NoAssessmentItemWithId(assessmentItemId);
 
         JoinOrLaunchSession();
-        return aim.SeekSolution();
+        return aim.RecordSolutionRequest();
     }
 
     private Result NoAssessmentItemWithId(int assessmentItemId)

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/LearnerAssessmentService.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/LearnerAssessmentService.cs
@@ -1,7 +1,6 @@
 ﻿using FluentResults;
 using System;
 using Tutor.Core.DomainModel.AssessmentItems;
-using Tutor.Core.LearnerModel.DomainOverlay.KnowledgeComponentMasteries.Events.AssessmentItemEvents;
 
 namespace Tutor.Core.LearnerModel.DomainOverlay
 {
@@ -14,13 +13,12 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
             _kcMasteryRepository = kcMasteryRepository;
         }
 
-        public Result<Evaluation> EvaluateAndSaveSubmission(int learnerId, int assessmentItemId, Submission submission)
+        public Result<Evaluation> SubmitAssessmentItemAnswer(int learnerId, int assessmentItemId, Submission submission)
         {
             var assessmentItem = _kcMasteryRepository.GetDerivedAssessmentItem(assessmentItemId);
             if (assessmentItem == null) return Result.Fail("No assessment item with ID: " + assessmentItemId);
-
-            var kcm = _kcMasteryRepository.GetFullKcMastery(assessmentItem.KnowledgeComponentId, learnerId);
-            if (kcm == null) return Result.Fail("Learner not enrolled in KC: " + assessmentItem.KnowledgeComponentId);
+            var kcMastery = _kcMasteryRepository.GetFullKcMastery(assessmentItem.KnowledgeComponentId, learnerId);
+            if (kcMastery == null) return Result.Fail("Learner not enrolled in KC: " + assessmentItem.KnowledgeComponentId);
 
             Evaluation evaluation;
             try
@@ -32,8 +30,10 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
                 return Result.Fail(ex.Message);
             }
 
-            kcm.SubmitAssessmentItemAnswer(assessmentItemId, submission, evaluation);
-            _kcMasteryRepository.UpdateKcMastery(kcm);
+            var result = kcMastery.RecordAssessmentItemAnswerSubmission(assessmentItemId, submission, evaluation);
+            if (result.IsFailed) return result.ToResult<Evaluation>();
+
+            _kcMasteryRepository.UpdateKcMastery(kcMastery);
 
             return Result.Ok(evaluation);
         }
@@ -50,9 +50,9 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
             var kcm = _kcMasteryRepository.GetKcMasteryForAssessmentItem(assessmentItemId, learnerId);
             if (kcm == null) return Result.Fail("Cannot seek hints for assessment item with ID: " + assessmentItemId);
 
-            var result = kcm.SeekHintsForAssessmentItem(assessmentItemId);
+            var result = kcm.RecordAssessmentItemHintRequest(assessmentItemId);
 
-            _kcMasteryRepository.UpdateKcMastery(kcm);
+            if (result.IsSuccess) _kcMasteryRepository.UpdateKcMastery(kcm);
 
             return result;
         }
@@ -62,21 +62,23 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
             var kcm = _kcMasteryRepository.GetKcMasteryForAssessmentItem(assessmentItemId, learnerId);
             if (kcm == null) return Result.Fail("Cannot seek solution for assessment item with ID: " + assessmentItemId);
 
-            var result = kcm.SeekSolutionForAssessmentItem(assessmentItemId);
+            var result = kcm.RecordAssessmentItemSolutionRequest(assessmentItemId);
 
-            _kcMasteryRepository.UpdateKcMastery(kcm);
+            if (result.IsSuccess) _kcMasteryRepository.UpdateKcMastery(kcm);
 
             return result;
         }
 
         //Should be moved to an instructor service or whatever will be used to interact with the chatbot
-        public Result SaveInstructorMessage(int learnerId, int kcId, string message)
+        public Result RecordInstructorMessage(int learnerId, int kcId, string message)
         {
             var kcm = _kcMasteryRepository.GetBasicKcMastery(kcId, learnerId);
             if (kcm == null) return Result.Fail("Learner not enrolled in KC: " + kcId);
 
             var result = kcm.RecordInstructorMessage(message);
-            _kcMasteryRepository.UpdateKcMastery(kcm);
+
+            if (result.IsSuccess) _kcMasteryRepository.UpdateKcMastery(kcm);
+
             return result;
         }
     }

--- a/src/Tutor.Core/LearnerModel/DomainOverlay/LearnerAssessmentService.cs
+++ b/src/Tutor.Core/LearnerModel/DomainOverlay/LearnerAssessmentService.cs
@@ -45,7 +45,7 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
             return Result.Ok(itemMastery?.Mastery ?? 0.0);
         }
 
-        public Result SeekChallengeHints(int learnerId, int assessmentItemId)
+        public Result RecordHintRequest(int learnerId, int assessmentItemId)
         {
             var kcm = _kcMasteryRepository.GetKcMasteryForAssessmentItem(assessmentItemId, learnerId);
             if (kcm == null) return Result.Fail("Cannot seek hints for assessment item with ID: " + assessmentItemId);
@@ -57,7 +57,7 @@ namespace Tutor.Core.LearnerModel.DomainOverlay
             return result;
         }
 
-        public Result SeekChallengeSolution(int learnerId, int assessmentItemId)
+        public Result RecordSolutionRequest(int learnerId, int assessmentItemId)
         {
             var kcm = _kcMasteryRepository.GetKcMasteryForAssessmentItem(assessmentItemId, learnerId);
             if (kcm == null) return Result.Fail("Cannot seek solution for assessment item with ID: " + assessmentItemId);

--- a/src/Tutor.Infrastructure/EventConfiguration/EventSerializationConfiguration.cs
+++ b/src/Tutor.Infrastructure/EventConfiguration/EventSerializationConfiguration.cs
@@ -16,8 +16,8 @@ namespace Tutor.Infrastructure.EventConfiguration
         public static readonly IImmutableDictionary<Type, string> EventRelatedTypes = new Dictionary<Type, string>
         {
             { typeof(AssessmentItemAnswered), "AssessmentItemAnswered" },
-            { typeof(SoughtHints), "SoughtChallengeHints" },
-            { typeof(SoughtSolution), "SoughtChallengeSolution" },
+            { typeof(HintsRequested), "SoughtChallengeHints" },
+            { typeof(SolutionRequested), "SoughtChallengeSolution" },
             { typeof(KnowledgeComponentStarted), "KnowledgeComponentStarted" },
             { typeof(KnowledgeComponentPassed), "KnowledgeComponentPassed" },
             { typeof(KnowledgeComponentCompleted), "KnowledgeComponentCompleted" },

--- a/src/Tutor.Web/Controllers/Learners/DomainOverlay/LearnerAssessmentController.cs
+++ b/src/Tutor.Web/Controllers/Learners/DomainOverlay/LearnerAssessmentController.cs
@@ -36,7 +36,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult<ChallengeEvaluationDto> SubmitChallenge(
             [FromBody] ChallengeSubmissionDto submission)
         {
-            var result = _learnerAssessmentService.EvaluateAndSaveSubmission(submission.LearnerId, submission.AssessmentItemId, _mapper.Map<ChallengeSubmission>(submission));
+            var result = _learnerAssessmentService.SubmitAssessmentItemAnswer(submission.LearnerId, submission.AssessmentItemId, _mapper.Map<ChallengeSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<ChallengeEvaluationDto>(result.Value));
         }
@@ -45,7 +45,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult<List<MrqItemEvaluationDto>> SubmitMultipleResponseQuestion(
             [FromBody] MrqSubmissionDto submission)
         {
-            var result = _learnerAssessmentService.EvaluateAndSaveSubmission(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<MrqSubmission>(submission));
+            var result = _learnerAssessmentService.SubmitAssessmentItemAnswer(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<MrqSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<MrqEvaluationDto>(result.Value));
         }
@@ -54,7 +54,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult<McqEvaluationDto> SubmitMultiChoiceQuestion(
             [FromBody] McqSubmissionDto submission)
         {
-            var result = _learnerAssessmentService.EvaluateAndSaveSubmission(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<McqSubmission>(submission));
+            var result = _learnerAssessmentService.SubmitAssessmentItemAnswer(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<McqSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<McqEvaluationDto>(result.Value));
         }
@@ -63,7 +63,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult<List<AtContainerEvaluationDto>> SubmitArrangeTask(
             [FromBody] AtSubmissionDto submission)
         {
-            var result = _learnerAssessmentService.EvaluateAndSaveSubmission(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<ArrangeTaskSubmission>(submission));
+            var result = _learnerAssessmentService.SubmitAssessmentItemAnswer(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<ArrangeTaskSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<AtEvaluationDto>(result.Value));
         }
@@ -72,7 +72,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult<List<SaqEvaluationDto>> SubmitShortAnswerQuestion(
             [FromBody] SaqSubmissionDto submission)
         {
-            var result = _learnerAssessmentService.EvaluateAndSaveSubmission(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<SaqSubmission>(submission));
+            var result = _learnerAssessmentService.SubmitAssessmentItemAnswer(User.LearnerId(), submission.AssessmentItemId, _mapper.Map<SaqSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<SaqEvaluationDto>(result.Value));
         }
@@ -91,7 +91,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult SaveInstructorMessage([FromBody] InstructorMessageDto instructorMessageDto)
         {
             var result = _learnerAssessmentService
-                .SaveInstructorMessage(User.LearnerId(), instructorMessageDto.KcId, instructorMessageDto.Message);
+                .RecordInstructorMessage(User.LearnerId(), instructorMessageDto.KcId, instructorMessageDto.Message);
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok();
         }

--- a/src/Tutor.Web/Controllers/Learners/DomainOverlay/PluginController.cs
+++ b/src/Tutor.Web/Controllers/Learners/DomainOverlay/PluginController.cs
@@ -36,7 +36,7 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         public ActionResult<ChallengeEvaluationDto> SubmitChallenge(
             [FromBody] ChallengeSubmissionDto submission)
         {
-            var result = _learnerAssessmentService.EvaluateAndSaveSubmission(submission.LearnerId, submission.AssessmentItemId, _mapper.Map<ChallengeSubmission>(submission));
+            var result = _learnerAssessmentService.SubmitAssessmentItemAnswer(submission.LearnerId, submission.AssessmentItemId, _mapper.Map<ChallengeSubmission>(submission));
             if (result.IsFailed) return BadRequest(result.Errors);
             return Ok(_mapper.Map<ChallengeEvaluationDto>(result.Value));
         }

--- a/src/Tutor.Web/Controllers/Learners/DomainOverlay/PluginController.cs
+++ b/src/Tutor.Web/Controllers/Learners/DomainOverlay/PluginController.cs
@@ -42,15 +42,15 @@ namespace Tutor.Web.Controllers.Learners.DomainOverlay
         }
 
         [HttpPost("challenge/hints")]
-        public void SeekHints([FromBody] ChallengeSubmissionDto submission)
+        public void RequestHints([FromBody] ChallengeSubmissionDto submission)
         {
-            _learnerAssessmentService.SeekChallengeHints(submission.LearnerId, submission.AssessmentItemId);
+            _learnerAssessmentService.RecordHintRequest(submission.LearnerId, submission.AssessmentItemId);
         }
 
         [HttpPost("challenge/solution")]
-        public void SeekSolution([FromBody] ChallengeSubmissionDto submission)
+        public void RequestSolution([FromBody] ChallengeSubmissionDto submission)
         {
-            _learnerAssessmentService.SeekChallengeSolution(submission.LearnerId, submission.AssessmentItemId);
+            _learnerAssessmentService.RecordSolutionRequest(submission.LearnerId, submission.AssessmentItemId);
         }
     }
 }


### PR DESCRIPTION
- Removes logic for getting instructional items from KCM. 
- Removes logic for coordination with IAssessmentItemSelector from KCM.
- Renames KCM methods to make their purpose clearer. 
- Renames events and methods related to hints and solution to use 'request' instead of 'seek', since they convey the same meaning, but 'request' is a far more common word and 'seek' seems somewhat unwieldy. 