### PR TITLE
Support for SessionPause/SessionContinue.

### DIFF
--- a/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionContinued.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionContinued.cs
@@ -2,5 +2,4 @@
 
 public class SessionContinued : SessionLifecycleEvent
 {
-    
 }

--- a/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionContinued.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionContinued.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.Domain.KnowledgeMastery.Events.SessionLifecycleEvents;
+
+public class SessionContinued : SessionLifecycleEvent
+{
+    
+}

--- a/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionPaused.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionPaused.cs
@@ -1,0 +1,6 @@
+﻿namespace Tutor.Core.Domain.KnowledgeMastery.Events.SessionLifecycleEvents;
+
+public class SessionPaused : SessionLifecycleEvent
+{
+    
+}

--- a/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionPaused.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/Events/SessionLifecycleEvents/SessionPaused.cs
@@ -2,5 +2,4 @@
 
 public class SessionPaused : SessionLifecycleEvent
 {
-    
 }

--- a/src/Tutor.Core/Domain/KnowledgeMastery/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/KnowledgeComponentMastery.cs
@@ -71,6 +71,16 @@ public class KnowledgeComponentMastery : EventSourcedAggregateRoot
         return SessionTracker.Abandon();
     }
 
+    public Result PauseSession()
+    {
+        return SessionTracker.Pause();
+    }
+
+    public Result ContinueSession()
+    {
+        return SessionTracker.Continue();
+    }
+
     private void JoinOrLaunchSession()
     {
         if (!SessionTracker.HasUnfinishedSession) LaunchSession();

--- a/src/Tutor.Core/Domain/KnowledgeMastery/KnowledgeComponentMastery.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/KnowledgeComponentMastery.cs
@@ -233,6 +233,6 @@ public class KnowledgeComponentMastery : EventSourcedAggregateRoot
 
     private static void When(KnowledgeComponentEvent @event)
     {
-        // No action for AssessmentItemSelected, InstructionalItemsSelected, SolutionRequest, InstructorMessageEvent, SessionTerminated, SessionAbandoned.
+        // No action for AssessmentItemSelected, InstructionalItemsSelected, SolutionRequest, InstructorMessageEvent, and SessionLifecycle events.
     }
 }

--- a/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
@@ -14,10 +14,9 @@ public class SessionTracker : EventSourcedEntity
     public TimeSpan DurationOfFinishedSessions { get; private set; } = new(0);
     public bool HasUnfinishedSession => StartOfUnfinishedSession.HasValue;
 
-    public TimeSpan? DurationOfUnfinishedSession => HasUnfinishedSession ? LastActivity.Value - StartOfUnfinishedSession.Value : null;
+    public TimeSpan? DurationOfUnfinishedSession => HasUnfinishedSession ? DateTime.UtcNow - StartOfUnfinishedSession.Value : null;
     public DateTime? StartOfUnfinishedSession { get; private set; }
-    public DateTime? LastActivity { get; private set; }
-    
+
     public bool IsPaused { get; private set; }
     public TimeSpan DurationOfAllPauses => DurationOfFinishedPauses + DurationOfUnfinishedPauses.GetValueOrDefault();
     public TimeSpan DurationOfFinishedPauses { get; private set; } = new(0);
@@ -81,29 +80,22 @@ public class SessionTracker : EventSourcedEntity
     private void When(SessionLaunched @event)
     {
         StartOfUnfinishedSession = @event.TimeStamp;
-        LastActivity = @event.TimeStamp;
         CountOfSessions++;
     }
 
     private void When(SessionTerminated @event)
     {
-        LastActivity = @event.TimeStamp;
-
         DurationOfFinishedSessions += DurationOfUnfinishedSession.GetValueOrDefault();
         StartOfUnfinishedSession = null;
-        LastActivity = null;
     }
 
     private void When(SessionPaused @event)
     {
         LastPause = @event.TimeStamp;
-        
-        LastActivity = LastPause.Value.AddMinutes(-3);
     }
 
     private void When(SessionContinued @event)
     {
-        LastActivity = @event.TimeStamp;
         DurationOfFinishedPauses += @event.TimeStamp - LastPause.Value;
         LastPause = null;
     }
@@ -112,29 +104,24 @@ public class SessionTracker : EventSourcedEntity
     {
         DurationOfFinishedSessions += DurationOfUnfinishedSession.GetValueOrDefault();
         StartOfUnfinishedSession = null;
-        LastActivity = null;
     }
 
     private void When(KnowledgeComponentCompleted @event)
     {
-        LastActivity = @event.TimeStamp;
         @event.MinutesToCompletion = DurationOfAllSessions.TotalMinutes;
     }
 
     private void When(KnowledgeComponentPassed @event)
     {
-        LastActivity = @event.TimeStamp;
         @event.MinutesToPass = DurationOfAllSessions.TotalMinutes;
     }
 
     private void When(KnowledgeComponentSatisfied @event)
     {
-        LastActivity = @event.TimeStamp;
         @event.MinutesToSatisfaction = DurationOfAllSessions.TotalMinutes;
     }
 
     private void When(KnowledgeComponentEvent @event)
     {
-        LastActivity = @event.TimeStamp;
     }
 }

--- a/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
@@ -18,10 +18,10 @@ public class SessionTracker : EventSourcedEntity
     public DateTime? StartOfUnfinishedSession { get; private set; }
 
     public bool IsPaused { get; private set; }
-    public TimeSpan DurationOfAllPauses => DurationOfFinishedPauses + DurationOfUnfinishedPauses.GetValueOrDefault();
+    public TimeSpan DurationOfAllPauses => DurationOfFinishedPauses + DurationOfUnfinishedPause.GetValueOrDefault();
     public TimeSpan DurationOfFinishedPauses { get; private set; } = new(0);
-    public TimeSpan? DurationOfUnfinishedPauses => IsPaused ? DateTime.UtcNow - LastPause.Value : null;
-    public DateTime? LastPause { get; private set; }
+    public TimeSpan? DurationOfUnfinishedPause => IsPaused ? DateTime.UtcNow - UnfinishedPauseStart.Value : null;
+    public DateTime? UnfinishedPauseStart { get; private set; }
 
     public void Launch()
     {
@@ -91,13 +91,13 @@ public class SessionTracker : EventSourcedEntity
 
     private void When(SessionPaused @event)
     {
-        LastPause = @event.TimeStamp;
+        UnfinishedPauseStart = @event.TimeStamp;
     }
 
     private void When(SessionContinued @event)
     {
-        DurationOfFinishedPauses += @event.TimeStamp - LastPause.Value;
-        LastPause = null;
+        DurationOfFinishedPauses += @event.TimeStamp - UnfinishedPauseStart.Value;
+        UnfinishedPauseStart = null;
     }
 
     private void When(SessionAbandoned @event)

--- a/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
@@ -108,17 +108,17 @@ public class SessionTracker : EventSourcedEntity
 
     private void When(KnowledgeComponentCompleted @event)
     {
-        @event.MinutesToCompletion = DurationOfAllSessions.TotalMinutes;
+        @event.MinutesToCompletion = DurationOfAllSessions.TotalMinutes - DurationOfAllPauses.TotalMinutes;
     }
 
     private void When(KnowledgeComponentPassed @event)
     {
-        @event.MinutesToPass = DurationOfAllSessions.TotalMinutes;
+        @event.MinutesToPass = DurationOfAllSessions.TotalMinutes - DurationOfAllPauses.TotalMinutes;
     }
 
     private void When(KnowledgeComponentSatisfied @event)
     {
-        @event.MinutesToSatisfaction = DurationOfAllSessions.TotalMinutes;
+        @event.MinutesToSatisfaction = DurationOfAllSessions.TotalMinutes - DurationOfAllPauses.TotalMinutes;
     }
 
     private void When(KnowledgeComponentEvent @event)

--- a/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
@@ -38,8 +38,8 @@ public class SessionTracker : EventSourcedEntity
     {
         if (!HasUnfinishedSession) return Result.Fail("No active session to terminate.");
         if (IsPaused) Continue();
-
-            Causes(new SessionTerminated());
+        
+        Causes(new SessionTerminated());
         return Result.Ok();
     }
 

--- a/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
+++ b/src/Tutor.Core/Domain/KnowledgeMastery/SessionTracker.cs
@@ -14,13 +14,13 @@ public class SessionTracker : EventSourcedEntity
     public TimeSpan DurationOfFinishedSessions { get; private set; } = new(0);
     public bool HasUnfinishedSession => StartOfUnfinishedSession.HasValue;
 
-    public TimeSpan? DurationOfUnfinishedSession => HasUnfinishedSession ? DateTime.UtcNow - StartOfUnfinishedSession.Value : null;
+    public TimeSpan? DurationOfUnfinishedSession => HasUnfinishedSession ? DateTime.UtcNow - StartOfUnfinishedSession.Value : TimeSpan.Zero;
     public DateTime? StartOfUnfinishedSession { get; private set; }
 
     public bool IsPaused { get; private set; }
     public TimeSpan DurationOfAllPauses => DurationOfFinishedPauses + DurationOfUnfinishedPause.GetValueOrDefault();
     public TimeSpan DurationOfFinishedPauses { get; private set; } = new(0);
-    public TimeSpan? DurationOfUnfinishedPause => IsPaused ? DateTime.UtcNow - UnfinishedPauseStart.Value : null;
+    public TimeSpan? DurationOfUnfinishedPause => IsPaused ? DateTime.UtcNow - UnfinishedPauseStart.Value : TimeSpan.Zero;
     public DateTime? UnfinishedPauseStart { get; private set; }
 
     public void Launch()

--- a/src/Tutor.Core/UseCases/Learning/ISessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/ISessionService.cs
@@ -6,8 +6,8 @@ public interface ISessionService
 {
     Result LaunchSession(int knowledgeComponentId, int learnerId);
     Result TerminateSession(int knowledgeComponentId, int learnerId);
-
     Result PauseSession(int knowledgeComponentId, int learnerId);
-
     Result ContinueSession(int knowledgeComponentId, int learnerId);
+    Result AbandonSession(int knowledgeComponentId, int learnerId);
+
 }

--- a/src/Tutor.Core/UseCases/Learning/ISessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/ISessionService.cs
@@ -9,5 +9,4 @@ public interface ISessionService
     Result PauseSession(int knowledgeComponentId, int learnerId);
     Result ContinueSession(int knowledgeComponentId, int learnerId);
     Result AbandonSession(int knowledgeComponentId, int learnerId);
-
 }

--- a/src/Tutor.Core/UseCases/Learning/ISessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/ISessionService.cs
@@ -6,4 +6,8 @@ public interface ISessionService
 {
     Result LaunchSession(int knowledgeComponentId, int learnerId);
     Result TerminateSession(int knowledgeComponentId, int learnerId);
+
+    Result PauseSession(int knowledgeComponentId, int learnerId);
+
+    Result ContinueSession(int knowledgeComponentId, int learnerId);
 }

--- a/src/Tutor.Core/UseCases/Learning/SessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/SessionService.cs
@@ -28,10 +28,7 @@ public class SessionService : ISessionService
 
         kcMastery.LaunchSession();
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
-        var result = _unitOfWork.Save();
-        if (result.IsFailed) return result;
-
-        return result;
+        return _unitOfWork.Save();
     }
 
     public Result TerminateSession(int knowledgeComponentId, int learnerId)
@@ -45,10 +42,7 @@ public class SessionService : ISessionService
         var result = kcMastery.TerminateSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
-        result = _unitOfWork.Save();
-        if (result.IsFailed) return result;
-
-        return result;
+        return _unitOfWork.Save();
     }
 
     public Result PauseSession(int knowledgeComponentId, int learnerId)
@@ -62,10 +56,7 @@ public class SessionService : ISessionService
         var result = kcMastery.PauseSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
-        result = _unitOfWork.Save();
-        if (result.IsFailed) return result;
-
-        return result;
+        return _unitOfWork.Save();
     }
 
     public Result ContinueSession(int knowledgeComponentId, int learnerId)
@@ -79,10 +70,7 @@ public class SessionService : ISessionService
         var result = kcMastery.ContinueSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
-        result = _unitOfWork.Save();
-        if (result.IsFailed) return result;
-
-        return result;
+        return _unitOfWork.Save();
     }
 
     public Result AbandonSession(int knowledgeComponentId, int learnerId)
@@ -96,9 +84,6 @@ public class SessionService : ISessionService
         var result = kcMastery.AbandonSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
-        result = _unitOfWork.Save();
-        if (result.IsFailed) return result;
-
-        return result;
+        return _unitOfWork.Save();
     }
 }

--- a/src/Tutor.Core/UseCases/Learning/SessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/SessionService.cs
@@ -20,12 +20,10 @@ public class SessionService : ISessionService
 
     public Result LaunchSession(int knowledgeComponentId, int learnerId)
     {
-        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
-            return Result.Fail(FailureCode.NotEnrolledInUnit);
+        var result = TryGetKcMastery(knowledgeComponentId, learnerId);
+        if (result.IsFailed) return result.ToResult();
 
-        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
-        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
-
+        var kcMastery = result.Value;
         kcMastery.LaunchSession();
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
         return _unitOfWork.Save();
@@ -33,12 +31,10 @@ public class SessionService : ISessionService
 
     public Result TerminateSession(int knowledgeComponentId, int learnerId)
     {
-        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
-            return Result.Fail(FailureCode.NotEnrolledInUnit);
+        var kcMasteryResult = TryGetKcMastery(knowledgeComponentId, learnerId);
+        if (kcMasteryResult.IsFailed) return kcMasteryResult.ToResult();
 
-        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
-        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
-
+        var kcMastery = kcMasteryResult.Value;
         var result = kcMastery.TerminateSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
@@ -47,12 +43,10 @@ public class SessionService : ISessionService
 
     public Result PauseSession(int knowledgeComponentId, int learnerId)
     {
-        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
-            return Result.Fail(FailureCode.NotEnrolledInUnit);
+        var kcMasteryResult = TryGetKcMastery(knowledgeComponentId, learnerId);
+        if (kcMasteryResult.IsFailed) return kcMasteryResult.ToResult();
 
-        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
-        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
-
+        var kcMastery = kcMasteryResult.Value;
         var result = kcMastery.PauseSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
@@ -61,12 +55,10 @@ public class SessionService : ISessionService
 
     public Result ContinueSession(int knowledgeComponentId, int learnerId)
     {
-        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
-            return Result.Fail(FailureCode.NotEnrolledInUnit);
+        var kcMasteryResult = TryGetKcMastery(knowledgeComponentId, learnerId);
+        if (kcMasteryResult.IsFailed) return kcMasteryResult.ToResult();
 
-        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
-        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
-
+        var kcMastery = kcMasteryResult.Value;
         var result = kcMastery.ContinueSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
@@ -75,15 +67,21 @@ public class SessionService : ISessionService
 
     public Result AbandonSession(int knowledgeComponentId, int learnerId)
     {
-        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
-            return Result.Fail(FailureCode.NotEnrolledInUnit);
+        var kcMasteryResult = TryGetKcMastery(knowledgeComponentId, learnerId);
+        if (kcMasteryResult.IsFailed) return kcMasteryResult.ToResult();
 
-        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
-        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
-
+        var kcMastery = kcMasteryResult.Value;
         var result = kcMastery.AbandonSession();
         if (result.IsFailed) return result;
         _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
         return _unitOfWork.Save();
+    }
+
+    private Result<KnowledgeComponentMastery> TryGetKcMastery(int knowledgeComponentId, int learnerId)
+    {
+        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId)) return Result.Fail(FailureCode.NotEnrolledInUnit);
+        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
+        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
+        return Result.Ok(kcMastery);
     }
 }

--- a/src/Tutor.Core/UseCases/Learning/SessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/SessionService.cs
@@ -50,4 +50,38 @@ public class SessionService : ISessionService
 
         return result;
     }
+
+    public Result PauseSession(int knowledgeComponentId, int learnerId)
+    {
+        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
+            return Result.Fail(FailureCode.NotEnrolledInUnit);
+
+        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
+        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
+
+        var result = kcMastery.PauseSession();
+        if (result.IsFailed) return result;
+        _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
+        result = _unitOfWork.Save();
+        if (result.IsFailed) return result;
+
+        return result;
+    }
+
+    public Result ContinueSession(int knowledgeComponentId, int learnerId)
+    {
+        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
+            return Result.Fail(FailureCode.NotEnrolledInUnit);
+
+        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
+        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
+
+        var result = kcMastery.ContinueSession();
+        if (result.IsFailed) return result;
+        _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
+        result = _unitOfWork.Save();
+        if (result.IsFailed) return result;
+
+        return result;
+    }
 }

--- a/src/Tutor.Core/UseCases/Learning/SessionService.cs
+++ b/src/Tutor.Core/UseCases/Learning/SessionService.cs
@@ -84,4 +84,21 @@ public class SessionService : ISessionService
 
         return result;
     }
+
+    public Result AbandonSession(int knowledgeComponentId, int learnerId)
+    {
+        if (!_enrollmentRepository.HasActiveEnrollmentForKc(knowledgeComponentId, learnerId))
+            return Result.Fail(FailureCode.NotEnrolledInUnit);
+
+        var kcMastery = _knowledgeMasteryRepository.GetBareKcMastery(knowledgeComponentId, learnerId);
+        if (kcMastery == null) return Result.Fail(FailureCode.NotFound);
+
+        var result = kcMastery.AbandonSession();
+        if (result.IsFailed) return result;
+        _knowledgeMasteryRepository.UpdateKcMastery(kcMastery);
+        result = _unitOfWork.Save();
+        if (result.IsFailed) return result;
+
+        return result;
+    }
 }

--- a/src/Tutor.Infrastructure/Database/EventStore/EventSerializationConfiguration.cs
+++ b/src/Tutor.Infrastructure/Database/EventStore/EventSerializationConfiguration.cs
@@ -27,6 +27,8 @@ public static class EventSerializationConfiguration
         { typeof(SessionLaunched), "SessionLaunched" },
         { typeof(SessionTerminated), "SessionTerminated" },
         { typeof(SessionAbandoned), "SessionAbandoned" },
+        { typeof(SessionPaused), "SessionPaused"},
+        { typeof(SessionContinued), "SessionContinued"},
         { typeof(InstructionalItemsSelected), "InstructionalItemsSelected" },
         { typeof(EncouragingMessageSent), "EncouragingMessageSent" },
         #region Submissions

--- a/src/Tutor.Infrastructure/Database/TutorContext.cs
+++ b/src/Tutor.Infrastructure/Database/TutorContext.cs
@@ -191,6 +191,8 @@ public class TutorContext : DbContext
         {
             trackerBuilder.Property(tracker => tracker.CountOfSessions).IsRequired().HasDefaultValue(0);
             trackerBuilder.Property(tracker => tracker.DurationOfFinishedSessions).IsRequired().HasDefaultValue(TimeSpan.Zero);
+            trackerBuilder.Property(tracker => tracker.IsPaused).IsRequired().HasDefaultValue(false);
+            trackerBuilder.Property(tracker => tracker.DurationOfFinishedPauses).IsRequired().HasDefaultValue(TimeSpan.Zero);
             trackerBuilder.Ignore(tracker => tracker.Id);
         });
         kcmBuilder.Navigation(kcm => kcm.SessionTracker).IsRequired();

--- a/src/Tutor.Web/Controllers/Learners/Learning/SessionController.cs
+++ b/src/Tutor.Web/Controllers/Learners/Learning/SessionController.cs
@@ -31,4 +31,21 @@ public class SessionController : BaseApiController
         if (result.IsFailed) return CreateErrorResponse(result.Errors);
         return Ok();
     }
+    
+    [HttpPost("pauseSession")]
+    public ActionResult Pause(int knowledgeComponentId)
+    {
+        var result = _sessionService.PauseSession(knowledgeComponentId, User.LearnerId());
+        if (result.IsFailed) return CreateErrorResponse(result.Errors);
+        return Ok();
+    }
+    
+    [HttpPost("continueSession")]
+    public ActionResult TerminatePause(int knowledgeComponentId)
+    {
+        var result = _sessionService.ContinueSession(knowledgeComponentId, User.LearnerId());
+        if (result.IsFailed) return CreateErrorResponse(result.Errors);
+        return Ok();
+    }
+    
 }

--- a/src/Tutor.Web/Controllers/Learners/Learning/SessionController.cs
+++ b/src/Tutor.Web/Controllers/Learners/Learning/SessionController.cs
@@ -32,7 +32,7 @@ public class SessionController : BaseApiController
         return Ok();
     }
     
-    [HttpPost("pauseSession")]
+    [HttpPost("pause")]
     public ActionResult Pause(int knowledgeComponentId)
     {
         var result = _sessionService.PauseSession(knowledgeComponentId, User.LearnerId());
@@ -40,7 +40,7 @@ public class SessionController : BaseApiController
         return Ok();
     }
     
-    [HttpPost("continueSession")]
+    [HttpPost("continue")]
     public ActionResult TerminatePause(int knowledgeComponentId)
     {
         var result = _sessionService.ContinueSession(knowledgeComponentId, User.LearnerId());
@@ -48,4 +48,11 @@ public class SessionController : BaseApiController
         return Ok();
     }
     
+    [HttpPost("abandon")]
+    public ActionResult AbandonSession(int knowledgeComponentId)
+    {
+        var result = _sessionService.AbandonSession(knowledgeComponentId, User.LearnerId());
+        if (result.IsFailed) return CreateErrorResponse(result.Errors);
+        return Ok();
+    }
 }

--- a/src/Tutor.Web/Mappings/Enrollments/GroupProfile.cs
+++ b/src/Tutor.Web/Mappings/Enrollments/GroupProfile.cs
@@ -13,13 +13,8 @@ public class GroupProfile : Profile
         CreateMap<GroupDto, LearnerGroup>();
 
         CreateMap<KnowledgeComponentMastery, KcmProgressDto>()
-            .ForMember(dest => dest.DurationOfAllSessionsInMinutes, opt => opt.MapFrom(src =>
-                (src.SessionTracker.DurationOfAllSessions.Hours * 60) +
-                src.SessionTracker.DurationOfAllSessions.Minutes))
-            .ForMember(dest => dest.DurationOfAllPausesInMinutes, opt => opt.MapFrom(src =>
-                (src.SessionTracker.DurationOfAllPauses.Hours * 60) +
-                src.SessionTracker.DurationOfAllPauses.Minutes));
-
+            .ForMember(dest => dest.ActiveSessionInMinutes, opt => opt.MapFrom(src =>
+                src.SessionTracker.DurationOfAllSessions.TotalMinutes - src.SessionTracker.DurationOfAllPauses.TotalMinutes));
         CreateMap<UnitEnrollment, UnitEnrollmentDto>()
             .ForMember(dest => dest.Status, 
                 opt => opt.MapFrom(

--- a/src/Tutor.Web/Mappings/Enrollments/GroupProfile.cs
+++ b/src/Tutor.Web/Mappings/Enrollments/GroupProfile.cs
@@ -15,7 +15,10 @@ public class GroupProfile : Profile
         CreateMap<KnowledgeComponentMastery, KcmProgressDto>()
             .ForMember(dest => dest.DurationOfAllSessionsInMinutes, opt => opt.MapFrom(src =>
                 (src.SessionTracker.DurationOfAllSessions.Hours * 60) +
-                src.SessionTracker.DurationOfAllSessions.Minutes));
+                src.SessionTracker.DurationOfAllSessions.Minutes))
+            .ForMember(dest => dest.DurationOfAllPausesInMinutes, opt => opt.MapFrom(src =>
+                (src.SessionTracker.DurationOfAllPauses.Hours * 60) +
+                src.SessionTracker.DurationOfAllPauses.Minutes));
 
         CreateMap<UnitEnrollment, UnitEnrollmentDto>()
             .ForMember(dest => dest.Status, 

--- a/src/Tutor.Web/Mappings/Enrollments/KcmProgressDto.cs
+++ b/src/Tutor.Web/Mappings/Enrollments/KcmProgressDto.cs
@@ -10,4 +10,5 @@ public class KcmProgressDto
     public KcMasteryStatisticsDto Statistics { get; set; }
     public List<AssessmentItemMasteryDto> AssessmentItemMasteries { get; set; }
     public int DurationOfAllSessionsInMinutes { get; set; }
+    public int DurationOfAllPausesInMinutes { get; set; }
 }

--- a/src/Tutor.Web/Mappings/Enrollments/KcmProgressDto.cs
+++ b/src/Tutor.Web/Mappings/Enrollments/KcmProgressDto.cs
@@ -9,6 +9,5 @@ public class KcmProgressDto
     public int KnowledgeComponentId { get; set; }
     public KcMasteryStatisticsDto Statistics { get; set; }
     public List<AssessmentItemMasteryDto> AssessmentItemMasteries { get; set; }
-    public int DurationOfAllSessionsInMinutes { get; set; }
-    public int DurationOfAllPausesInMinutes { get; set; }
+    public int ActiveSessionInMinutes { get; set; }
 }

--- a/tests/Tutor.Web.Tests/Integration/Learning/SessionTests.cs
+++ b/tests/Tutor.Web.Tests/Integration/Learning/SessionTests.cs
@@ -41,6 +41,139 @@ public class SessionTests : BaseWebIntegrationTest
         terminationResult.ShouldNotBeNull();
         terminationResult.StatusCode.ShouldBe(500);
     }
+    
+    [Fact]
+    public void Launch_and_pause_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var pauseResult = controller.Pause(-15);
+
+        launchResult.ShouldBeOfType<OkResult>();
+        pauseResult.ShouldBeOfType<OkResult>();
+    }
+    
+    [Fact]
+    public void Launch_pause_continue_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var pauseResult = controller.Pause(-15);
+        var continueResult = controller.TerminatePause(-15);
+        
+        launchResult.ShouldBeOfType<OkResult>();
+        pauseResult.ShouldBeOfType<OkResult>();
+        continueResult.ShouldBeOfType<OkResult>();
+    }
+    
+    [Fact]
+    public void Launch_pause_continue_terminate_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var pauseResult = controller.Pause(-15);
+        var continueResult = controller.TerminatePause(-15);
+        var terminateResult = controller.TerminateSession(-15);
+        
+        launchResult.ShouldBeOfType<OkResult>();
+        pauseResult.ShouldBeOfType<OkResult>();
+        continueResult.ShouldBeOfType<OkResult>();
+        terminateResult.ShouldBeOfType<OkResult>();
+    }
+    
+    [Fact]
+    public void Launch_pause_continue_abandon_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var pauseResult = controller.Pause(-15);
+        var continueResult = controller.TerminatePause(-15);
+        var abandonResult = controller.AbandonSession(-15);
+        
+        launchResult.ShouldBeOfType<OkResult>();
+        pauseResult.ShouldBeOfType<OkResult>();
+        continueResult.ShouldBeOfType<OkResult>();
+        abandonResult.ShouldBeOfType<OkResult>();
+    }
+    
+    [Fact]
+    public void Launch_pause_abandon_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var pauseResult = controller.Pause(-15);
+        var abandonResult = controller.AbandonSession(-15);
+        
+        launchResult.ShouldBeOfType<OkResult>();
+        pauseResult.ShouldBeOfType<OkResult>();
+        abandonResult.ShouldBeOfType<OkResult>();
+    }
+    
+    [Fact]
+    public void Launch_pause_terminate_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var pauseResult = controller.Pause(-15);
+        var terminateResult = controller.TerminateSession(-15);
+        
+        launchResult.ShouldBeOfType<OkResult>();
+        pauseResult.ShouldBeOfType<OkResult>();
+        terminateResult.ShouldBeOfType<OkResult>();
+    }
+    
+    [Fact]
+    public void Pause_fails_without_active_session()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var pauseResult = (ObjectResult)controller.Pause(-15);
+
+        pauseResult.ShouldNotBeNull();
+        pauseResult.StatusCode.ShouldBe(500);
+    }
+    
+    [Fact]
+    public void Continue_fails_without_active_pause()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var controller = SetupSessionController(scope, "-2");
+        var dbContext = scope.ServiceProvider.GetRequiredService<TutorContext>();
+        dbContext.Database.BeginTransaction();
+
+        var launchResult = controller.LaunchSession(-15);
+        var continueResult = (ObjectResult)controller.TerminatePause(-15);
+
+        continueResult.ShouldNotBeNull();
+        continueResult.StatusCode.ShouldBe(500);
+    }
 
     private static SessionController SetupSessionController(IServiceScope scope, string id)
     {


### PR DESCRIPTION
**Change goal:** The goal of this PR is to measure the learner's activity during the session. From now instructor will be able to see the effective time of each session (DurationOfAllSessions - DurationOfAllPauses).
**Required database changes:** KcMasteries table has additional columns (SessionTracker_IsPaused, SessionTracker_DurationOfFinishedPauses, SessionTracker_UnfinishedPauseStart).