### PR TITLE
Fix/delete learner

### DIFF
--- a/src/Tutor.Infrastructure/Database/TutorContext.cs
+++ b/src/Tutor.Infrastructure/Database/TutorContext.cs
@@ -221,12 +221,14 @@ public class TutorContext : DbContext
     {
         modelBuilder.Entity<GroupMembership>()
             .HasOne(g => g.Member)
-            .WithMany();
+            .WithMany()
+            .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<UnitEnrollment>()
             .HasOne<Learner>()
             .WithMany()
-            .HasForeignKey(u => u.LearnerId);
+            .HasForeignKey(u => u.LearnerId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 
     private static void ConfigureLearningUtilities(ModelBuilder modelBuilder)


### PR DESCRIPTION
## Goal

Cascade delete UnitEnrollments and GroupMemberships when deleting Learner.

## Tests

- Adds tests for delete Learner.
- Adds tests for potential update Stakeholder bug cause.
