### PR TITLE
Analytics expansion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.API/Dtos/KnowledgeAnalytics/SubmissionCountDto.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.API/Dtos/KnowledgeAnalytics/SubmissionCountDto.cs
@@ -1,0 +1,9 @@
+﻿using Tutor.KnowledgeComponents.API.Dtos.Knowledge.AssessmentItems;
+
+namespace Tutor.KnowledgeComponents.API.Dtos.KnowledgeAnalytics;
+
+public class SubmissionCountDto
+{
+    public int Count { get; set; }
+    public SubmissionDto Submission { get; set; }
+}

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.API/Public/Analysis/IAssessmentAnalysisService.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.API/Public/Analysis/IAssessmentAnalysisService.cs
@@ -6,4 +6,5 @@ namespace Tutor.KnowledgeComponents.API.Public.Analysis;
 public interface IAssessmentAnalysisService
 {
     Result<List<AiStatisticsDto>> GetStatistics(int kcId, int instructorId);
+    Result<List<SubmissionCountDto>> Get5MostFrequentWrongSubmissions(int kcId, int aiId, int instructorId);
 }

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.API/Public/Analysis/IMisconceptionAnalysisService.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.API/Public/Analysis/IMisconceptionAnalysisService.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+using Tutor.KnowledgeComponents.API.Dtos.KnowledgeAnalytics;
+
+namespace Tutor.KnowledgeComponents.API.Public.Analysis;
+
+public interface IMisconceptionAnalysisService
+{
+    Result<List<AiStatisticsDto>> GetTop10MisconceivedAssessments(int unitId, int instructorId);
+}

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Domain/Knowledge/AssessmentItems/MultiResponseQuestions/MrqSubmission.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Domain/Knowledge/AssessmentItems/MultiResponseQuestions/MrqSubmission.cs
@@ -5,6 +5,6 @@ public class MrqSubmission : Submission
     public List<string> SubmittedAnswers { get; private set; }
     protected override IEnumerable<object> GetEqualityComponents()
     {
-        return SubmittedAnswers;
+        yield return string.Join(';', SubmittedAnswers.OrderByDescending(a => a));
     }
 }

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Domain/KnowledgeAnalytics/AssessmentStatisticsCalculator.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Domain/KnowledgeAnalytics/AssessmentStatisticsCalculator.cs
@@ -21,7 +21,7 @@ public class AssessmentStatisticsCalculator
         return new AiStatistics
         {
             AiId = aiId,
-            KcId = events.First().KnowledgeComponentId,
+            KcId = eventsGroupedByLearner.First().First().KnowledgeComponentId,
             MinutesToCompletion = minutesToCompletion,
             AttemptsToPass = attemptsToPass
         };

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Domain/KnowledgeAnalytics/AssessmentStatisticsCalculator.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Domain/KnowledgeAnalytics/AssessmentStatisticsCalculator.cs
@@ -1,0 +1,54 @@
+﻿using Tutor.BuildingBlocks.Core.EventSourcing;
+using Tutor.KnowledgeComponents.Core.Domain.KnowledgeMastery.Events.AssessmentItemEvents;
+
+namespace Tutor.KnowledgeComponents.Core.Domain.KnowledgeAnalytics;
+
+public class AssessmentStatisticsCalculator
+{
+    public AiStatistics Calculate(int aiId, List<AssessmentItemEvent> events)
+    {
+        var eventsGroupedByLearner = events
+            .Where(e => e.AssessmentItemId == aiId)
+            .GroupBy(e => e.LearnerId)
+            .ToList();
+
+        var minutesToCompletion = eventsGroupedByLearner
+            .Select(CalculateCompletionTime).Where(completionTime => completionTime != 0).ToList();
+
+        var attemptsToPass = eventsGroupedByLearner
+            .Select(CalculateAttemptsToPass).Where(completionTime => completionTime != 0).ToList();
+
+        return new AiStatistics
+        {
+            AiId = aiId,
+            KcId = events.First().KnowledgeComponentId,
+            MinutesToCompletion = minutesToCompletion,
+            AttemptsToPass = attemptsToPass
+        };
+    }
+
+    private static double CalculateCompletionTime(IEnumerable<AssessmentItemEvent> events)
+    {
+        var aiEvents = events.ToList();
+        var firstAiCompletion = aiEvents.OfType<AssessmentItemAnswered>().FirstOrDefault();
+
+        if (firstAiCompletion == null) return 0;
+
+        return CalculateMinuteDifference(firstAiCompletion, aiEvents.First());
+    }
+
+    private static int CalculateAttemptsToPass(IEnumerable<AssessmentItemEvent> events)
+    {
+        var aiEvents = events.ToList();
+        var firstAiPass = aiEvents.OfType<AssessmentItemAnswered>().FirstOrDefault(e => e.Feedback.Evaluation.Correct);
+
+        if (firstAiPass == null) return 0;
+
+        return aiEvents.OfType<AssessmentItemAnswered>().Count(e => e.TimeStamp <= firstAiPass.TimeStamp);
+    }
+
+    private static double CalculateMinuteDifference(DomainEvent secondEvent, DomainEvent firstEvent)
+    {
+        return Math.Round((secondEvent.TimeStamp - firstEvent.TimeStamp).TotalMinutes, 2);
+    }
+}

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Mappers/AssessmentItemsProfile.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/Mappers/AssessmentItemsProfile.cs
@@ -19,6 +19,7 @@ public class AssessmentItemsProfile : Profile
         CreateMap<AssessmentItem, AssessmentItemDto>().IncludeAllDerived()
             .ForMember(dest => dest.Hints, opt => opt.MapFrom(src => src.Hints.Select(h => h.Markdown)));
         CreateMap<SubmissionDto, Submission>().IncludeAllDerived();
+        CreateMap<Submission, SubmissionDto>().IncludeAllDerived();
         CreateMap<Evaluation, EvaluationDto>().IncludeAllDerived();
         
         CreateMap<Feedback, FeedbackDto>()
@@ -28,13 +29,13 @@ public class AssessmentItemsProfile : Profile
         #region Short answer question
         CreateMap<Saq, SaqDto>().ReverseMap();
         CreateMap<SaqEvaluation, SaqEvaluationDto>();
-        CreateMap<SaqSubmissionDto, SaqSubmission>();
+        CreateMap<SaqSubmissionDto, SaqSubmission>().ReverseMap();
         #endregion
 
         #region Multiple choice question
         CreateMap<Mcq, McqDto>().ReverseMap();
         CreateMap<McqEvaluation, McqEvaluationDto>();
-        CreateMap<McqSubmissionDto, McqSubmission>();
+        CreateMap<McqSubmissionDto, McqSubmission>().ReverseMap();
         #endregion
 
         #region Multiple response question
@@ -42,6 +43,9 @@ public class AssessmentItemsProfile : Profile
         CreateMap<MrqItem, MrqItemDto>().ReverseMap();
         CreateMap<MrqSubmissionDto, MrqSubmission>()
             .ForMember(dest => dest.SubmittedAnswers, opt => opt.MapFrom(src => src.Answers.Select(a => a.Text)));
+        CreateMap<MrqSubmission, MrqSubmissionDto>()
+            .ForMember(dest => dest.Answers,
+                opt => opt.MapFrom(src => src.SubmittedAnswers.Select(a => new MrqItemDto { Text = a })));
         CreateMap<MrqEvaluation, MrqEvaluationDto>();
         CreateMap<MrqItemEvaluation, MrqItemEvaluationDto>()
             .ForMember(dest => dest.Text, opt => opt.MapFrom(src => src.FullItem.Text))

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/UseCases/Analysis/AssessmentAnalysisService.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/UseCases/Analysis/AssessmentAnalysisService.cs
@@ -48,7 +48,6 @@ public class AssessmentAnalysisService : IAssessmentAnalysisService
         return aiIds.Select(aiId => _mapper.Map<AiStatisticsDto>(_calculator.Calculate(aiId, sortedAiEvents))).ToList();
     }
 
-
     public Result<List<SubmissionCountDto>> Get5MostFrequentWrongSubmissions(int kcId, int aiId, int instructorId)
     {
         if (!_accessService.IsKcOwner(kcId, instructorId))

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/UseCases/Analysis/MisconceptionAnalysisService.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Core/UseCases/Analysis/MisconceptionAnalysisService.cs
@@ -5,37 +5,45 @@ using Tutor.BuildingBlocks.Core.UseCases;
 using Tutor.KnowledgeComponents.API.Dtos.KnowledgeAnalytics;
 using Tutor.KnowledgeComponents.API.Public;
 using Tutor.KnowledgeComponents.API.Public.Analysis;
+using Tutor.KnowledgeComponents.Core.Domain.Knowledge.RepositoryInterfaces;
 using Tutor.KnowledgeComponents.Core.Domain.KnowledgeAnalytics;
 using Tutor.KnowledgeComponents.Core.Domain.KnowledgeMastery.Events;
 using Tutor.KnowledgeComponents.Core.Domain.KnowledgeMastery.Events.AssessmentItemEvents;
 
 namespace Tutor.KnowledgeComponents.Core.UseCases.Analysis;
 
-public class AssessmentAnalysisService : IAssessmentAnalysisService
+public class MisconceptionAnalysisService : IMisconceptionAnalysisService
 {
     private readonly IMapper _mapper;
     private readonly IAccessService _accessService;
     private readonly IEventStore _eventStore;
+    private readonly IKnowledgeComponentRepository _kcRepository;
     private readonly AssessmentStatisticsCalculator _calculator;
 
-    public AssessmentAnalysisService(IMapper mapper, IAccessService accessService, IEventStore eventStore)
+    public MisconceptionAnalysisService(IMapper mapper, IAccessService accessService, IEventStore eventStore, IKnowledgeComponentRepository kcRepository)
     {
         _mapper = mapper;
         _accessService = accessService;
         _eventStore = eventStore;
+        _kcRepository = kcRepository;
         _calculator = new AssessmentStatisticsCalculator();
     }
 
-    public Result<List<AiStatisticsDto>> GetStatistics(int kcId, int instructorId)
+    public Result<List<AiStatisticsDto>> GetTop10MisconceivedAssessments(int unitId, int instructorId)
     {
-        if(!_accessService.IsKcOwner(kcId, instructorId))
+        if(!_accessService.IsUnitOwner(unitId, instructorId))
             return Result.Fail(FailureCode.Forbidden);
 
+        var kcIds = _kcRepository.GetByUnit(unitId).Select(kc => kc.Id).ToList();
+
         var events = _eventStore.Events
-            .Where(e => e.RootElement.GetProperty("KnowledgeComponentId").GetInt32() == kcId)
+            .Where(e => kcIds.Contains(e.RootElement.GetProperty("KnowledgeComponentId").GetInt32()))
             .ToList<KnowledgeComponentEvent>();
 
-        return CalculateStatistics(events);
+        return CalculateStatistics(events)
+            .OrderByDescending(e => e.AttemptsToPass.Average())
+            .Take(10)
+            .ToList();
     }
 
     private List<AiStatisticsDto> CalculateStatistics(List<KnowledgeComponentEvent> events)

--- a/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Infrastructure/KnowledgeComponentsStartup.cs
+++ b/src/Modules/KnowledgeComponents/Tutor.KnowledgeComponents.Infrastructure/KnowledgeComponentsStartup.cs
@@ -52,6 +52,7 @@ public static class KnowledgeComponentsStartup
         services.AddProxiedScoped<IAccessService, AccessServices>();
 
         services.AddProxiedScoped<IAssessmentAnalysisService, AssessmentAnalysisService>();
+        services.AddProxiedScoped<IMisconceptionAnalysisService, MisconceptionAnalysisService>();
         services.AddProxiedScoped<IKnowledgeAnalysisService, KnowledgeAnalysisService>();
         services.AddProxiedScoped<IRatingService, RatingService>();
 

--- a/src/Tutor.API/Controllers/Instructor/Analysis/AssessmentAnalysisController.cs
+++ b/src/Tutor.API/Controllers/Instructor/Analysis/AssessmentAnalysisController.cs
@@ -23,4 +23,11 @@ public class AssessmentAnalysisController : BaseApiController
         var result = _assessmentAnalysisService.GetStatistics(kcId, User.InstructorId());
         return CreateResponse(result);
     }
+
+    [HttpGet("{aiId:int}")]
+    public ActionResult<List<SubmissionCountDto>> GetCommonIncorrectSubmissions(int kcId, int aiId)
+    {
+        var result = _assessmentAnalysisService.Get5MostFrequentWrongSubmissions(kcId, aiId, User.InstructorId());
+        return CreateResponse(result);
+    }
 }

--- a/src/Tutor.API/Controllers/Instructor/Analysis/UnitAnalysisController.cs
+++ b/src/Tutor.API/Controllers/Instructor/Analysis/UnitAnalysisController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Tutor.KnowledgeComponents.API.Dtos.KnowledgeAnalytics;
+using Tutor.KnowledgeComponents.API.Public.Analysis;
+using Tutor.Stakeholders.Infrastructure.Authentication;
+
+namespace Tutor.API.Controllers.Instructor.Analysis;
+
+[Authorize(Policy = "instructorPolicy")]
+[Route("api/analysis/units/{unitId:int}")]
+public class UnitAnalysisController : BaseApiController
+{
+    private readonly IMisconceptionAnalysisService _misconceptionService;
+
+    public UnitAnalysisController(IMisconceptionAnalysisService misconceptionService)
+    {
+        _misconceptionService = misconceptionService;
+    }
+
+    [HttpGet]
+    public ActionResult<List<AiStatisticsDto>> GetTop10MisconceivedAssessments(int unitId)
+    {
+        var result = _misconceptionService.GetTop10MisconceivedAssessments(unitId, User.InstructorId());
+        return CreateResponse(result);
+    }
+}


### PR DESCRIPTION
Expands instructor analytics use cases with the following endpoints:

- Get top 10 misconceived assessment items (i.e., highest average number of submissions before completion).
- Get top 5 incorrect submissions for an assessment item (opened as part of AI authoring controls).