### PR TITLE
feat: Adds support for manual LLM-based validation when authoring assessment items

### DIFF
--- a/src/Modules/Courses/Tutor.Courses.Core/Domain/SystemPrompt.cs
+++ b/src/Modules/Courses/Tutor.Courses.Core/Domain/SystemPrompt.cs
@@ -7,4 +7,12 @@ public class SystemPrompt : Entity
     public string Category { get; private set; }
     public string Code { get; private set; }
     public string Content { get; private set; }
+
+    public SystemPrompt(int id, string category, string code, string content)
+    {
+        Id = id;
+        Category = category;
+        Code = code;
+        Content = content;
+    }
 }

--- a/src/Modules/Courses/Tutor.Courses.Core/Domain/SystemPrompt.cs
+++ b/src/Modules/Courses/Tutor.Courses.Core/Domain/SystemPrompt.cs
@@ -1,0 +1,10 @@
+﻿using Tutor.BuildingBlocks.Core.Domain;
+
+namespace Tutor.Courses.Core.Domain;
+
+public class SystemPrompt : Entity
+{
+    public string Category { get; private set; }
+    public string Code { get; private set; }
+    public string Content { get; private set; }
+}

--- a/src/Modules/Courses/Tutor.Courses.Infrastructure/CoursesStartup.cs
+++ b/src/Modules/Courses/Tutor.Courses.Infrastructure/CoursesStartup.cs
@@ -69,6 +69,7 @@ public static class CoursesStartup
         
         services.AddScoped<IWeeklyFeedbackRepository, WeeklyFeedbackDatabaseRepository>();
         services.AddScoped<IUnitProgressRatingRepository, UnitProgressRatingRepository>();
+        services.AddScoped(typeof(ICrudRepository<SystemPrompt>), typeof(CrudDatabaseRepository<SystemPrompt, CoursesContext>));
 
         services.AddScoped<ICoursesUnitOfWork, CoursesUnitOfWork>();
         services.AddDbContext<CoursesContext>(opt =>

--- a/src/Modules/Courses/Tutor.Courses.Infrastructure/Database/CoursesContext.cs
+++ b/src/Modules/Courses/Tutor.Courses.Infrastructure/Database/CoursesContext.cs
@@ -8,6 +8,7 @@ public class CoursesContext : DbContext
     public DbSet<Course> Courses { get; set; }
     public DbSet<CourseOwnership> CourseOwnerships { get; set; }
     public DbSet<KnowledgeUnit> KnowledgeUnits { get; set; }
+    public DbSet<SystemPrompt> SystemPrompts { get; set; }
     public DbSet<LearnerGroup> LearnerGroups { get; set; }
     public DbSet<UnitEnrollment> UnitEnrollments { get; set; }
     public DbSet<UnitProgressRating> UnitProgressRating { get; set; }

--- a/src/Tutor.API/Controllers/Instructor/Authoring/AuthoringPromptsController.cs
+++ b/src/Tutor.API/Controllers/Instructor/Authoring/AuthoringPromptsController.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Tutor.BuildingBlocks.Core.UseCases;
+using Tutor.Courses.Core.Domain;
+
+namespace Tutor.API.Controllers.Instructor.Authoring;
+
+[Route("api/authoring/prompts")]
+[Authorize(Policy = "instructorPolicy")]
+public class AuthoringPromptsController : BaseApiController
+{
+    private readonly ICrudRepository<SystemPrompt> _promptRepository;
+
+    public AuthoringPromptsController(ICrudRepository<SystemPrompt> promptRepository)
+    {
+        _promptRepository = promptRepository;
+    }
+
+    [HttpGet]
+    public ActionResult<List<SystemPrompt>> GetAll()
+    {
+        var results = _promptRepository.GetPaged(0, 0);
+        return Ok(results.Results);
+    }
+}


### PR DESCRIPTION
### Change Goal

- Support instructors in reducing errors when authoring assessment items.

### Database Change
Apply the following SQL:
```sql
CREATE TABLE IF NOT EXISTS courses."SystemPrompts"
(
    "Id" integer NOT NULL GENERATED BY DEFAULT AS IDENTITY ( INCREMENT 1 START 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 ),
    "Category" text COLLATE pg_catalog."default" NOT NULL,
    "Code" text COLLATE pg_catalog."default" NOT NULL,
    "Content" text COLLATE pg_catalog."default" NOT NULL,
    CONSTRAINT "PK_SystemPrompts" PRIMARY KEY ("Id")
)

TABLESPACE pg_default;

ALTER TABLE IF EXISTS courses."SystemPrompts"
    OWNER to postgres;
```